### PR TITLE
feat: add dev:local script for local network testing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
+const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+const localOrigins = appUrl ? [new URL(appUrl).hostname] : [];
+
 const nextConfig: NextConfig = {
   output: "standalone",
+  ...(localOrigins.length > 0 && { allowedDevOrigins: localOrigins }),
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "LOCAL_IP=$(hostname -I | awk '{print $1}') && BETTER_AUTH_URL=http://$LOCAL_IP:3000 NEXT_PUBLIC_APP_URL=http://$LOCAL_IP:3000 next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
Adds `npm run dev:local` which dynamically resolves the machine's local IP at startup and passes it as BETTER_AUTH_URL/NEXT_PUBLIC_APP_URL, so the app can be tested from a mobile device on the same network without manual IP configuration. Also configures allowedDevOrigins in next.config.ts dynamically from NEXT_PUBLIC_APP_URL to unblock HMR over local network.