### PR TITLE
fix: make dev:local IP detection cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "LOCAL_IP=$(hostname -I | awk '{print $1}') && BETTER_AUTH_URL=http://$LOCAL_IP:3000 NEXT_PUBLIC_APP_URL=http://$LOCAL_IP:3000 next dev -H 0.0.0.0",
+    "dev:local": "LOCAL_IP=$(node scripts/local-ip.mjs) && printf '\\n\\033[1;31m▲ Open the app at http://%s:3000 so that authentication works (localhost will fail).\\033[0m\\n\\n' \"$LOCAL_IP\" && BETTER_AUTH_URL=http://$LOCAL_IP:3000 NEXT_PUBLIC_APP_URL=http://$LOCAL_IP:3000 next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/scripts/local-ip.mjs
+++ b/scripts/local-ip.mjs
@@ -1,0 +1,12 @@
+import os from "node:os";
+
+for (const ifaces of Object.values(os.networkInterfaces())) {
+  for (const iface of ifaces ?? []) {
+    if (iface.family === "IPv4" && !iface.internal) {
+      console.log(iface.address);
+      process.exit(0);
+    }
+  }
+}
+
+console.log("127.0.0.1");


### PR DESCRIPTION
## Summary
- Replace Linux-only `hostname -I` in `dev:local` with `scripts/local-ip.mjs`, a tiny Node helper that reads `os.networkInterfaces()` — works on macOS, Linux, and Windows with no new deps.
- Print a bold-red banner with the actual LAN URL before Next starts, so users don't follow Next's `Network: http://0.0.0.0:3000` line and open localhost (which breaks auth because `BETTER_AUTH_URL` is bound to the LAN IP).

## Why
On macOS, `hostname -I` is not a valid flag (BSD `hostname`), so `LOCAL_IP` came out empty and `new URL("http://:3000")` in `next.config.ts` blew up with `ERR_INVALID_URL` before the dev server could even start.

## Test plan
- [x] `npm run dev:local` on macOS — red banner shows the LAN IP, app loads from `http://<lan-ip>:3000`, auth flows succeed.
- [x] `npm run dev:local` on Linux — same behaviour as before (`hostname -I` path is gone but `os.networkInterfaces()` returns the same IP).
- [x] `npm run dev` still binds to localhost only and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)