### PR TITLE
fix(timesheet): prevent native date picker auto-opening on mobile

### DIFF
--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -220,6 +220,7 @@ export function NewEntrySheet({
         <SheetContent
           side="bottom"
           className="rounded-t-2xl sm:max-w-lg sm:mx-auto"
+          onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <SheetHeader>
             <SheetTitle>Neuer Eintrag</SheetTitle>


### PR DESCRIPTION
## Summary
- The new-entry sheet (\"Eintrag hinzufügen\") was popping the native mobile date picker the moment it opened.
- Root cause: Radix Dialog (which powers our `Sheet`) auto-focuses the first focusable element on open. That happens to be the `<Input type=\"date\">`, and focusing a native date input on mobile triggers the system picker.
- Fix: pass `onOpenAutoFocus={(e) => e.preventDefault()}` to `SheetContent` so nothing is focused when the sheet opens.

## Test plan
- [ ] On mobile (iOS Safari + Chrome Android), tap \"Eintrag hinzufügen\" — sheet opens with no date picker shown.
- [ ] Tapping the date field still opens the native picker normally.
- [ ] Desktop: sheet opens, no input is auto-focused; tabbing reaches fields in order.
- [ ] Saving an entry still works end-to-end (date, times, signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)