### PR TITLE
fix(timesheet): narrow event.child include to avoid Decimal leak

### DIFF
--- a/src/features/timesheet/services/index.ts
+++ b/src/features/timesheet/services/index.ts
@@ -82,7 +82,9 @@ export async function getEventsForUserInRange(
 ) {
   return prisma.event.findMany({
     where: { userId, date: { gte: start, lt: endExclusive } },
-    include: { child: true },
+    include: {
+      child: { select: { id: true, firstName: true, lastName: true } },
+    },
     orderBy: [{ date: "asc" }, { startTime: "asc" }],
   });
 }


### PR DESCRIPTION
## Summary
- Dev server logs were flooded with `Only plain objects can be passed to Client Components from Server Components. Decimal objects are not supported.` warnings on every page render that lists events.
- Root cause: `getEventsForUserInRange` (`src/features/timesheet/services/index.ts`) uses `include: { child: true }`, which pulls the full `Child` row — now including `schoolLat`/`schoolLng` as `Prisma.Decimal` after the recent seed-kinder-cost-bearers schema changes. The landing page (`src/app/page.tsx`) passes events straight to `SchoolAssistantApp` (a Client Component), and React's serializer warns once per Decimal field per event.
- Fix: narrow the include to `{ id, firstName, lastName }` — the only fields the client UI (`tab-day.tsx`, `timesheet-shell.tsx`) actually reads from `event.child`.

## Test plan
- [x] Log in as a school assistant and load `/` — page renders normally, work events still show child first/last name.
- [x] Dev server log no longer prints the Decimal warning during `/` renders.
- [x] Monthly/weekly tabs that depend on events still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)