### PR TITLE
show Einsätze on Stundenplan blocks in week calendar

### DIFF
--- a/src/features/children/actions.ts
+++ b/src/features/children/actions.ts
@@ -114,3 +114,24 @@ export async function listWorkEventsForChildAction(childId: string) {
     userName: e.user.name,
   }));
 }
+
+export async function listWorkEventsForChildInRangeAction(
+  childId: string,
+  weekStart: string,
+) {
+  await requireAdmin();
+  const from = new Date(`${weekStart}T00:00:00.000Z`);
+  const to = new Date(from.getTime() + 6 * 24 * 60 * 60 * 1000);
+  const events = await ChildrenFacade.listWorkEventsForChildInRange(
+    childId,
+    from,
+    to,
+  );
+  return events.map((e) => ({
+    id: e.id,
+    date: e.date.toISOString().slice(0, 10),
+    startTime: e.startTime,
+    endTime: e.endTime,
+    userName: e.user.name,
+  }));
+}

--- a/src/features/children/components/calendar/schedule-einsatz-block.tsx
+++ b/src/features/children/components/calendar/schedule-einsatz-block.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import {
+  END_HOUR,
+  HOUR_HEIGHT,
+  START_HOUR,
+  snapHours,
+  parseTime,
+  type PositionedEvent,
+} from "./week-utils";
+import type { SerializedWorkEvent } from "../../serialize";
+
+type Props = {
+  ev: PositionedEvent;
+  col: number;
+  cols: number;
+  einsaetze: SerializedWorkEvent[];
+  onDelete: () => void;
+  onMove: (newStartHour: number, newEndHour: number) => void | Promise<void>;
+};
+
+function einsatzExceeds(
+  einsatz: SerializedWorkEvent,
+  scheduleStartHour: number,
+  scheduleEndHour: number,
+): boolean {
+  if (!einsatz.startTime || !einsatz.endTime) return false;
+  return (
+    parseTime(einsatz.startTime) < scheduleStartHour ||
+    parseTime(einsatz.endTime) > scheduleEndHour
+  );
+}
+
+export function ScheduleEinsatzBlock({
+  ev,
+  col,
+  cols,
+  einsaetze,
+  onDelete,
+  onMove,
+}: Props) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [dragOffset, setDragOffset] = useState<number | null>(null);
+
+  const top = (ev.startHour - START_HOUR) * HOUR_HEIGHT;
+  const height = Math.max(20, (ev.endHour - ev.startHour) * HOUR_HEIGHT);
+  const visualTopOffset = (dragOffset ?? 0) * HOUR_HEIGHT;
+
+  const SIDE_INSET = 4;
+  const TOP_INSET = 3;
+
+  const slotWidthPct = 100 / cols;
+  const leftPct = col * slotWidthPct;
+  const style: React.CSSProperties = {
+    top: top + visualTopOffset + TOP_INSET,
+    height: Math.max(12, height - 2 * TOP_INSET),
+    left: `calc(${leftPct}% + ${SIDE_INSET}px)`,
+    width: `calc(${slotWidthPct}% - ${2 * SIDE_INSET}px)`,
+  };
+
+  const anyExceeds = einsaetze.some((e) =>
+    einsatzExceeds(e, ev.startHour, ev.endHour),
+  );
+
+  const blockClasses = anyExceeds
+    ? "z-0 bg-red-500/15 border border-red-500/40 text-red-900 dark:text-red-200"
+    : "z-0 bg-sky-500/15 border border-sky-500/40 text-sky-900 dark:text-sky-200";
+
+  function handlePointerDown(e: React.PointerEvent<HTMLButtonElement>) {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+
+    const target = e.currentTarget;
+    target.setPointerCapture(e.pointerId);
+    const startY = e.clientY;
+    let dragged = false;
+    let lastOffset = 0;
+    const minOffset = START_HOUR - ev.startHour;
+    const maxOffset = END_HOUR - ev.endHour;
+
+    const onMoveEv = (mv: PointerEvent) => {
+      const dy = mv.clientY - startY;
+      if (Math.abs(dy) > 4) dragged = true;
+      const raw = snapHours(dy / HOUR_HEIGHT);
+      lastOffset = Math.max(minOffset, Math.min(maxOffset, raw));
+      setDragOffset(lastOffset);
+    };
+    const onUpEv = () => {
+      target.releasePointerCapture(e.pointerId);
+      target.removeEventListener("pointermove", onMoveEv);
+      target.removeEventListener("pointerup", onUpEv);
+      target.removeEventListener("pointercancel", onUpEv);
+      setDragOffset(null);
+      if (dragged && lastOffset !== 0) {
+        void onMove(ev.startHour + lastOffset, ev.endHour + lastOffset);
+      } else if (!dragged) {
+        setPopoverOpen(true);
+      }
+    };
+    target.addEventListener("pointermove", onMoveEv);
+    target.addEventListener("pointerup", onUpEv);
+    target.addEventListener("pointercancel", onUpEv);
+  }
+
+  return (
+    <Popover
+      open={popoverOpen}
+      onOpenChange={setPopoverOpen}
+    >
+      <PopoverAnchor asChild>
+        <button
+          type="button"
+          className={cn(
+            "absolute flex flex-col gap-0.5 overflow-hidden rounded px-1.5 py-1 text-left text-[11px] leading-tight cursor-grab hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            blockClasses,
+            dragOffset !== null && "ring-2 ring-primary cursor-grabbing",
+          )}
+          style={style}
+          onPointerDown={handlePointerDown}
+        >
+          {ev.sublabel && (
+            <div>
+              <span className="text-[9px] font-semibold uppercase tracking-wide opacity-50">
+                Stundenplan
+              </span>
+              <div className="font-medium">{ev.sublabel}</div>
+            </div>
+          )}
+          {einsaetze.map((e) => {
+            const exceeds = einsatzExceeds(e, ev.startHour, ev.endHour);
+            return (
+              <div
+                key={e.id}
+                className="border-t border-current/20 pt-0.5"
+              >
+                <span className="text-[9px] font-semibold uppercase tracking-wide opacity-50">
+                  Einsatz
+                </span>
+                <div className="truncate font-medium">{e.userName}</div>
+                <span
+                  className={cn(
+                    "font-semibold",
+                    exceeds && "text-red-700 dark:text-red-300",
+                  )}
+                >
+                  {e.startTime}–{e.endTime}
+                </span>
+              </div>
+            );
+          })}
+        </button>
+      </PopoverAnchor>
+      <PopoverContent
+        className="w-56 p-2"
+        align="start"
+        onPointerDown={(e) => e.stopPropagation()}
+        onPointerDownOutside={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex flex-col gap-2 text-sm"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <div>
+            <div className="font-medium text-xs text-muted-foreground mb-1">
+              Stundenplan {ev.sublabel}
+            </div>
+            {einsaetze.map((e) => {
+              const exceeds = einsatzExceeds(e, ev.startHour, ev.endHour);
+              return (
+                <div
+                  key={e.id}
+                  className="flex items-center gap-1.5"
+                >
+                  <span
+                    className={cn(
+                      "size-2 rounded-full shrink-0",
+                      exceeds ? "bg-red-500" : "bg-sky-500",
+                    )}
+                  />
+                  <span className="text-xs">
+                    <span className="font-medium">{e.userName}</span>{" "}
+                    {e.startTime}–{e.endTime}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={(e) => {
+              e.preventDefault();
+              onDelete();
+            }}
+          >
+            <Trash2 />
+            Löschen
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/features/children/components/calendar/week-calendar.tsx
+++ b/src/features/children/components/calendar/week-calendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -29,11 +29,13 @@ import {
 import { formatIsoDateLocal } from "@/lib/utils";
 import { EventCreateForm } from "./event-create-dialog";
 import { EventBlock } from "./event-block";
+import { ScheduleEinsatzBlock } from "./schedule-einsatz-block";
 import { DayQuickAddSection } from "./day-quick-add";
 import {
   deleteAbsenceAction,
   deleteAssignmentAction,
   deleteScheduleAction,
+  listWorkEventsForChildInRangeAction,
   updateAssignmentAction,
   updateScheduleAction,
 } from "../../actions";
@@ -41,6 +43,7 @@ import type {
   SerializedAbsence,
   SerializedAssignment,
   SerializedSchedule,
+  SerializedWorkEvent,
 } from "../../serialize";
 
 type SchoolAssistantOption = { id: string; name: string };
@@ -63,13 +66,11 @@ type DragState = {
 
 export type EventKind = "schedule" | "assignment" | "absence";
 
-// Static legend in the toolbar — the segmented kind-picker is gone now that
-// only Stundenplan is created via drag in the hour grid; Zuweisung +
-// Krankheit are added per day from the header's "+" button.
 const LEGEND_ITEMS: { label: string; swatch: string }[] = [
   { label: "Stundenplan", swatch: "bg-sky-500" },
   { label: "Zuweisung", swatch: "bg-primary/70" },
   { label: "Krankheit", swatch: "bg-red-500/70" },
+  { label: "Einsatz überschreitet", swatch: "bg-red-500" },
 ];
 
 const HOURS = Array.from(
@@ -89,9 +90,26 @@ export function KinderWeekCalendar({
   const [weekStart, setWeekStart] = useState<Date>(() =>
     startOfWeekMonday(new Date()),
   );
+  const [workEvents, setWorkEvents] = useState<SerializedWorkEvent[]>([]);
   const [drag, setDrag] = useState<DragState>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const weekStartIso = formatIsoDateLocal(weekStart);
+    listWorkEventsForChildInRangeAction(childId, weekStartIso)
+      .then(setWorkEvents)
+      .catch(() => setWorkEvents([]));
+  }, [childId, weekStart]);
+
+  const workEventsByDate = useMemo(() => {
+    const map = new Map<string, SerializedWorkEvent[]>();
+    for (const e of workEvents) {
+      if (!map.has(e.date)) map.set(e.date, []);
+      map.get(e.date)!.push(e);
+    }
+    return map;
+  }, [workEvents]);
 
   // Hour grid is schedules only — assignments and absences are whole-day
   // and live in the day-header chips, not the time grid.
@@ -330,6 +348,8 @@ export function KinderWeekCalendar({
 
           {DAY_LABELS_DE.map((label, weekday) => {
             const dayStacked = stacked.filter((e) => e.weekday === weekday);
+            const dateIso = formatIsoDateLocal(addDays(weekStart, weekday));
+            const dayEinsaetze = workEventsByDate.get(dateIso) ?? [];
             return (
               <div
                 key={label}
@@ -348,17 +368,28 @@ export function KinderWeekCalendar({
                   />
                 ))}
 
-                {/* Schedules only — assignment + absence live in the day header. */}
-                {dayStacked.map((ev) => (
-                  <EventBlock
-                    key={`${ev.layer}-${ev.id}`}
-                    ev={ev}
-                    col={ev.col}
-                    cols={ev.cols}
-                    onDelete={() => handleDelete(ev.layer, ev.id)}
-                    onMove={(s, e) => handleMove(ev, s, e)}
-                  />
-                ))}
+                {dayStacked.map((ev) =>
+                  ev.layer === "schedule" && dayEinsaetze.length > 0 ? (
+                    <ScheduleEinsatzBlock
+                      key={`schedule-einsatz-${ev.id}`}
+                      ev={ev}
+                      col={ev.col}
+                      cols={ev.cols}
+                      einsaetze={dayEinsaetze}
+                      onDelete={() => handleDelete(ev.layer, ev.id)}
+                      onMove={(s, e) => handleMove(ev, s, e)}
+                    />
+                  ) : (
+                    <EventBlock
+                      key={`${ev.layer}-${ev.id}`}
+                      ev={ev}
+                      col={ev.col}
+                      cols={ev.cols}
+                      onDelete={() => handleDelete(ev.layer, ev.id)}
+                      onMove={(s, e) => handleMove(ev, s, e)}
+                    />
+                  ),
+                )}
 
                 {dragSelection && dragSelection.weekday === weekday ? (
                   <Popover

--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -27,6 +27,7 @@ import {
   listSchedulesForChild,
   listSchedulesForChildren,
   listWorkEventsForChild,
+  listWorkEventsForChildInRange,
   updateAssignment,
   updateChild,
   updateSchedule,
@@ -172,5 +173,9 @@ export const ChildrenFacade = {
 
   async listWorkEventsForChild(childId: string) {
     return listWorkEventsForChild(childId);
+  },
+
+  async listWorkEventsForChildInRange(childId: string, from: Date, to: Date) {
+    return listWorkEventsForChildInRange(childId, from, to);
   },
 };

--- a/src/features/children/serialize.ts
+++ b/src/features/children/serialize.ts
@@ -24,6 +24,14 @@ export type SerializedAbsence = {
   note: string | null;
 };
 
+export type SerializedWorkEvent = {
+  id: string;
+  date: string; // YYYY-MM-DD
+  startTime: string | null;
+  endTime: string | null;
+  userName: string;
+};
+
 export type SerializedCostBearer = {
   id: string;
   name: string;

--- a/src/features/children/services/events.ts
+++ b/src/features/children/services/events.ts
@@ -14,3 +14,15 @@ export async function listWorkEventsForChild(
     orderBy: { date: "desc" },
   });
 }
+
+export async function listWorkEventsForChildInRange(
+  childId: string,
+  from: Date,
+  to: Date,
+): Promise<ChildWorkEvent[]> {
+  return prisma.event.findMany({
+    where: { childId, type: EventType.WORK, date: { gte: from, lte: to } },
+    include: { user: true },
+    orderBy: { date: "asc" },
+  });
+}


### PR DESCRIPTION
Displays work events (Einsätze) overlaid on Stundenplan blocks in the week calendar. Blocks 
 turn red when an Einsatz exceeds the scheduled time window (Einsatz > Stundenplan) , making it easy to spot when a 
 Schulbegleiter worked outside the planned hours.