### PR TITLE
fix(timesheet): gate Stundenplan by per-day assignment; fix seed weekday convention

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -201,16 +201,6 @@ function nthWeekdayBefore(n: number): Date {
   return dayOffset(i);
 }
 
-function nthWeekdayAfter(n: number): Date {
-  let count = 0;
-  let i = 0;
-  while (count < n) {
-    i += 1;
-    if (!isWeekend(dayOffset(i))) count += 1;
-  }
-  return dayOffset(i);
-}
-
 async function createUserViaAuth(user: SeedUser) {
   await prisma.invitation.deleteMany({ where: { email: user.email } });
   await prisma.invitation.create({
@@ -279,6 +269,9 @@ async function wipeSeedData() {
   await prisma.childAbsence.deleteMany({
     where: { childId: { in: childIds } },
   });
+  await prisma.childVertretung.deleteMany({
+    where: { childId: { in: childIds } },
+  });
   await prisma.schedule.deleteMany({ where: { childId: { in: childIds } } });
   await prisma.child.deleteMany({ where: { id: { in: childIds } } });
   await prisma.kostentraeger.deleteMany({
@@ -323,17 +316,55 @@ async function seedCostBearers() {
   }
 }
 
+// Per-child weekly Stundenplan (the child's school timetable). weekday uses
+// Mon=0..Sun=6, matching Schedule.weekday everywhere in the app. Multiple
+// blocks on the same weekday are intentional (e.g. a therapy gap) and mirror
+// what the data model and Vertretung copy logic already support.
+const CHILD_SCHEDULES: Record<
+  string,
+  { weekday: number; startTime: string; endTime: string }[]
+> = {
+  // Lena: Mon–Fri 08:00–13:00 (Anna covers the full window).
+  "seed-lena-fischer": [0, 1, 2, 3, 4].map((weekday) => ({
+    weekday,
+    startTime: "08:00",
+    endTime: "13:00",
+  })),
+  // Max: Mon–Fri 08:00–13:00 (Anna covers until 12:30).
+  "seed-max-huber": [0, 1, 2, 3, 4].map((weekday) => ({
+    weekday,
+    startTime: "08:00",
+    endTime: "13:00",
+  })),
+  // Mia: longer school days, Mon–Fri 08:00–14:00 (Ben covers 09:00–14:00).
+  "seed-mia-bauer": [0, 1, 2, 3, 4].map((weekday) => ({
+    weekday,
+    startTime: "08:00",
+    endTime: "14:00",
+  })),
+  // Paul: Mon–Fri 08:00–13:00, but Wednesday (weekday 2) is split around the
+  // 11–12 therapy slot that takes place outside of school.
+  "seed-paul-koch": [
+    { weekday: 0, startTime: "08:00", endTime: "13:00" },
+    { weekday: 1, startTime: "08:00", endTime: "13:00" },
+    { weekday: 2, startTime: "08:00", endTime: "11:00" },
+    { weekday: 2, startTime: "12:00", endTime: "13:00" },
+    { weekday: 3, startTime: "08:00", endTime: "13:00" },
+    { weekday: 4, startTime: "08:00", endTime: "13:00" },
+  ],
+};
+
 async function seedChildrenAndSchedules() {
   console.log("Seeding children & weekly schedules…");
   for (const c of CHILDREN) {
     await prisma.child.create({ data: c });
-    for (let weekday = 1; weekday <= 5; weekday++) {
+    for (const block of CHILD_SCHEDULES[c.id] ?? []) {
       await prisma.schedule.create({
         data: {
           childId: c.id,
-          weekday,
-          startTime: "08:00",
-          endTime: "13:00",
+          weekday: block.weekday,
+          startTime: block.startTime,
+          endTime: block.endTime,
         },
       });
     }
@@ -407,6 +438,8 @@ async function assignChildren(usersByEmail: Record<string, string>) {
   // Anna splits her week: Lena Mon/Wed/Fri, Max Tue/Thu.
   // Ben covers Mia all five weekdays. Clara covers Paul all five weekdays.
   // One day per pair is flagged tandem=true so the UI surfaces that variation.
+  // weekday uses Mon=0..Sun=6 (matches Schedule/ChildAssignment everywhere in
+  // the app: WEEKDAYS[0]="mon" and (getUTCDay()+6)%7), so Mon=0 … Fri=4.
   const assignments: Array<{
     childId: string;
     userId: string;
@@ -415,11 +448,11 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     endTime: string;
     tandem: boolean;
   }> = [
-    // Anna ↔ Lena
+    // Anna ↔ Lena (Mon/Wed/Fri)
     {
       childId: "seed-lena-fischer",
       userId: annaId,
-      weekday: 1,
+      weekday: 0,
       startTime: "08:00",
       endTime: "13:00",
       tandem: false,
@@ -427,7 +460,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     {
       childId: "seed-lena-fischer",
       userId: annaId,
-      weekday: 3,
+      weekday: 2,
       startTime: "08:00",
       endTime: "13:00",
       tandem: true,
@@ -435,16 +468,16 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     {
       childId: "seed-lena-fischer",
       userId: annaId,
-      weekday: 5,
+      weekday: 4,
       startTime: "08:00",
       endTime: "13:00",
       tandem: false,
     },
-    // Anna ↔ Max
+    // Anna ↔ Max (Tue/Thu)
     {
       childId: "seed-max-huber",
       userId: annaId,
-      weekday: 2,
+      weekday: 1,
       startTime: "08:00",
       endTime: "12:30",
       tandem: false,
@@ -452,7 +485,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     {
       childId: "seed-max-huber",
       userId: annaId,
-      weekday: 4,
+      weekday: 3,
       startTime: "08:00",
       endTime: "12:30",
       tandem: false,
@@ -461,6 +494,14 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     {
       childId: "seed-mia-bauer",
       userId: benId,
+      weekday: 0,
+      startTime: "09:00",
+      endTime: "14:00",
+      tandem: false,
+    },
+    {
+      childId: "seed-mia-bauer",
+      userId: benId,
       weekday: 1,
       startTime: "09:00",
       endTime: "14:00",
@@ -480,20 +521,12 @@ async function assignChildren(usersByEmail: Record<string, string>) {
       weekday: 3,
       startTime: "09:00",
       endTime: "14:00",
-      tandem: false,
-    },
-    {
-      childId: "seed-mia-bauer",
-      userId: benId,
-      weekday: 4,
-      startTime: "09:00",
-      endTime: "14:00",
       tandem: true,
     },
     {
       childId: "seed-mia-bauer",
       userId: benId,
-      weekday: 5,
+      weekday: 4,
       startTime: "09:00",
       endTime: "14:00",
       tandem: false,
@@ -502,6 +535,14 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     {
       childId: "seed-paul-koch",
       userId: claraId,
+      weekday: 0,
+      startTime: "08:00",
+      endTime: "13:00",
+      tandem: false,
+    },
+    {
+      childId: "seed-paul-koch",
+      userId: claraId,
       weekday: 1,
       startTime: "08:00",
       endTime: "13:00",
@@ -531,18 +572,60 @@ async function assignChildren(usersByEmail: Record<string, string>) {
       endTime: "13:00",
       tandem: false,
     },
-    {
-      childId: "seed-paul-koch",
-      userId: claraId,
-      weekday: 5,
-      startTime: "08:00",
-      endTime: "13:00",
-      tandem: false,
-    },
   ];
 
   for (const a of assignments) {
     await prisma.childAssignment.create({ data: a });
+  }
+}
+
+async function seedVertretungen(usersByEmail: Record<string, string>) {
+  console.log("Seeding Vertretungen (substitute coverage)…");
+  const annaId = usersByEmail["anna.schmidt@lebenshilfe.de"];
+  const claraId = usersByEmail["clara.becker@lebenshilfe.de"];
+
+  // Illustrative substitute coverage so the Vertretung UI (homepage cards,
+  // week calendar, admin views) has data to render. Each record copies the
+  // child's Stundenplan blocks for that weekday — exactly like
+  // ChildrenFacade.createVertretung — and uses a recent past weekday so no
+  // Vertretung lands in the future.
+  const vertretungen: Array<{
+    childId: string;
+    substituteUserId: string;
+    date: Date;
+  }> = [
+    // Anna steps in for Paul (normally Clara's) — populates Anna's homepage.
+    {
+      childId: "seed-paul-koch",
+      substituteUserId: annaId,
+      date: nthWeekdayBefore(4),
+    },
+    // Clara steps in for Max (normally Anna's).
+    {
+      childId: "seed-max-huber",
+      substituteUserId: claraId,
+      date: nthWeekdayBefore(6),
+    },
+  ];
+
+  for (const v of vertretungen) {
+    // Mon=0..Sun=6, matching Schedule.weekday.
+    const weekday = (v.date.getUTCDay() + 6) % 7;
+    const blocks = await prisma.schedule.findMany({
+      where: { childId: v.childId, weekday },
+      select: { startTime: true, endTime: true },
+    });
+    const timeBlocks =
+      blocks.length > 0 ? blocks : [{ startTime: "08:00", endTime: "13:00" }];
+    await prisma.childVertretung.createMany({
+      data: timeBlocks.map((b) => ({
+        childId: v.childId,
+        substituteUserId: v.substituteUserId,
+        date: v.date,
+        startTime: b.startTime,
+        endTime: b.endTime,
+      })),
+    });
   }
 }
 
@@ -606,47 +689,6 @@ const ANNA_PLAN: DraftEvent[] = [
     endTime: "13:00",
     note: "Wiedereinstieg nach Krankheit",
   },
-  {
-    offset: 1,
-    child: "seed-max-huber",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "12:30",
-    note: null,
-  },
-  // Following week
-  {
-    offset: 4,
-    child: "seed-lena-fischer",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "13:00",
-    note: null,
-  },
-  {
-    offset: 5,
-    child: "seed-max-huber",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "12:30",
-    note: "Sportunterricht in der Halle",
-  },
-  {
-    offset: 6,
-    child: "seed-lena-fischer",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "13:00",
-    note: null,
-  },
-  {
-    offset: 7,
-    child: "seed-max-huber",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "12:30",
-    note: null,
-  },
 ];
 
 const BEN_PLAN: DraftEvent[] = [
@@ -698,46 +740,6 @@ const BEN_PLAN: DraftEvent[] = [
     endTime: "14:00",
     note: null,
   },
-  {
-    offset: 1,
-    child: null,
-    type: EventType.SICK,
-    startTime: null,
-    endTime: null,
-    note: "Migräneanfall",
-  },
-  {
-    offset: 4,
-    child: "seed-mia-bauer",
-    type: EventType.WORK,
-    startTime: "09:00",
-    endTime: "14:00",
-    note: "Schulfest-Vorbereitung",
-  },
-  {
-    offset: 5,
-    child: "seed-mia-bauer",
-    type: EventType.WORK,
-    startTime: "09:00",
-    endTime: "14:00",
-    note: null,
-  },
-  {
-    offset: 6,
-    child: "seed-mia-bauer",
-    type: EventType.WORK,
-    startTime: "09:00",
-    endTime: "14:00",
-    note: null,
-  },
-  {
-    offset: 7,
-    child: "seed-mia-bauer",
-    type: EventType.WORK,
-    startTime: "09:00",
-    endTime: "14:00",
-    note: null,
-  },
 ];
 
 const CLARA_PLAN: DraftEvent[] = [
@@ -783,30 +785,6 @@ const CLARA_PLAN: DraftEvent[] = [
   },
   {
     offset: 0,
-    child: "seed-paul-koch",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "13:00",
-    note: null,
-  },
-  {
-    offset: 1,
-    child: "seed-paul-koch",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "13:00",
-    note: null,
-  },
-  {
-    offset: 4,
-    child: "seed-paul-koch",
-    type: EventType.WORK,
-    startTime: "08:00",
-    endTime: "13:00",
-    note: null,
-  },
-  {
-    offset: 5,
     child: "seed-paul-koch",
     type: EventType.WORK,
     startTime: "08:00",
@@ -902,7 +880,7 @@ async function seedWorkshopsAndAttendances() {
     {
       workshopId: "seed-ws-erste-hilfe",
       profileId: byEmail["anna.schmidt@lebenshilfe.de"],
-      attendedOn: nthWeekdayAfter(2),
+      attendedOn: nthWeekdayBefore(2),
     },
     {
       workshopId: "seed-ws-deeskalation",
@@ -912,7 +890,7 @@ async function seedWorkshopsAndAttendances() {
     {
       workshopId: "seed-ws-autismus",
       profileId: byEmail["clara.becker@lebenshilfe.de"],
-      attendedOn: nthWeekdayAfter(4),
+      attendedOn: nthWeekdayBefore(8),
     },
   ];
 
@@ -940,6 +918,7 @@ async function main() {
   await seedCostBearers();
   await seedChildrenAndSchedules();
   await assignChildren(usersByEmail);
+  await seedVertretungen(usersByEmail);
   await seedChildAbsences();
   await enrichProfiles();
   await seedEvents(usersByEmail);
@@ -955,7 +934,7 @@ async function main() {
   );
   console.log("=====================================");
   console.log(
-    `Events span ${dayOffset(-7).toISOString().slice(0, 10)} → ${dayOffset(7).toISOString().slice(0, 10)} (anchored to today).`,
+    `Events span ${dayOffset(-7).toISOString().slice(0, 10)} → ${TODAY.toISOString().slice(0, 10)} (past through today; no future entries).`,
   );
 }
 

--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -18,6 +18,8 @@ import { deleteEventAction } from "../actions";
 import type { Event, Schedule } from "@/generated/prisma";
 import type { ChildOption } from "./children-filter";
 import type { ChildAbsenceItem, VertretungDay } from "./timesheet-shell";
+import { childIdsForDate } from "../weekday";
+import type { AssignmentsByWeekday } from "../weekday";
 
 type EventWithChild = Event & {
   child: { firstName: string; lastName: string } | null;
@@ -33,6 +35,7 @@ type Props = {
   assignedChildren: ChildOption[];
   childAbsences: ChildAbsenceItem[];
   schedules: Schedule[];
+  assignmentsByWeekday: AssignmentsByWeekday;
   substituteOn?: VertretungDay[];
 };
 
@@ -48,6 +51,7 @@ export function TabDay({
   assignedChildren,
   childAbsences,
   schedules,
+  assignmentsByWeekday,
   substituteOn = [],
 }: Props) {
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -76,13 +80,11 @@ export function TabDay({
       .filter((a): a is ChildAbsenceItem & { child: ChildOption } => !!a.child);
   }, [childAbsences, selectedDateIso, childById]);
 
-  const substituteChildIds = useMemo(
-    () => new Set(substituteOn.map((v) => v.childId)),
-    [substituteOn],
-  );
-
   const daySchedules = useMemo(() => {
     const weekday = (selectedDate.getUTCDay() + 6) % 7;
+    const assignedToday = new Set(
+      childIdsForDate(assignmentsByWeekday, selectedDate),
+    );
     const todaySubstituteChildIds = new Set(
       substituteOn
         .filter((v) => v.date === selectedDateIso)
@@ -91,10 +93,13 @@ export function TabDay({
     return schedules
       .filter((s) => {
         if (s.weekday !== weekday) return false;
-        if (substituteChildIds.has(s.childId)) {
-          return todaySubstituteChildIds.has(s.childId);
-        }
-        return true;
+        // Only show a child's Stundenplan on days this user actually covers
+        // them — through a regular weekday assignment or by stepping in as
+        // today's substitute. Without this gate every assigned child would
+        // appear on every weekday, regardless of who is on duty.
+        return (
+          assignedToday.has(s.childId) || todaySubstituteChildIds.has(s.childId)
+        );
       })
       .map((s) => ({ ...s, child: childById.get(s.childId) }))
       .filter((s): s is Schedule & { child: ChildOption } => !!s.child)
@@ -104,7 +109,7 @@ export function TabDay({
     selectedDate,
     selectedDateIso,
     childById,
-    substituteChildIds,
+    assignmentsByWeekday,
     substituteOn,
   ]);
 

--- a/src/features/timesheet/components/tab-woche.tsx
+++ b/src/features/timesheet/components/tab-woche.tsx
@@ -7,6 +7,7 @@ import { WeekGrid } from "./week-grid";
 import { ChildrenFilter, type ChildOption } from "./children-filter";
 import type { Event, Schedule } from "@/generated/prisma";
 import type { VertretungDay } from "./timesheet-shell";
+import type { AssignmentsByWeekday } from "../weekday";
 
 type Props = {
   anchorDate: Date;
@@ -21,6 +22,7 @@ type Props = {
     Pick<Event, "id" | "date" | "type" | "startTime" | "endTime" | "childId">
   >;
   schedules: Schedule[];
+  assignmentsByWeekday: AssignmentsByWeekday;
   substituteOn?: VertretungDay[];
 };
 
@@ -35,6 +37,7 @@ export function TabWoche({
   onSelectedChildIdsChange,
   events,
   schedules,
+  assignmentsByWeekday,
   substituteOn = [],
 }: Props) {
   const monday = startOfWeekUtc(anchorDate);
@@ -101,6 +104,7 @@ export function TabWoche({
         selectedChildIds={selectedChildIds}
         events={events}
         schedules={schedules}
+        assignmentsByWeekday={assignmentsByWeekday}
         onSelectDay={onSelectDay}
         substituteOn={substituteOn}
       />

--- a/src/features/timesheet/components/timesheet-shell.tsx
+++ b/src/features/timesheet/components/timesheet-shell.tsx
@@ -173,6 +173,7 @@ export function SchoolAssistantApp({
             assignedChildren={assignedChildren}
             childAbsences={childAbsences}
             schedules={schedules}
+            assignmentsByWeekday={assignmentsByWeekday}
             substituteOn={substituteOn}
           />
         );
@@ -189,6 +190,7 @@ export function SchoolAssistantApp({
             onSelectedChildIdsChange={setSelectedChildIds}
             events={events}
             schedules={schedules}
+            assignmentsByWeekday={assignmentsByWeekday}
             substituteOn={substituteOn}
           />
         );

--- a/src/features/timesheet/components/week-grid.tsx
+++ b/src/features/timesheet/components/week-grid.tsx
@@ -12,6 +12,8 @@ import {
 import type { Event, Schedule } from "@/generated/prisma";
 import type { ChildOption } from "./children-filter";
 import type { VertretungDay } from "./timesheet-shell";
+import { childIdsForDate } from "../weekday";
+import type { AssignmentsByWeekday } from "../weekday";
 
 type Props = {
   anchorDate: Date;
@@ -22,6 +24,7 @@ type Props = {
     Pick<Event, "id" | "date" | "type" | "startTime" | "endTime" | "childId">
   >;
   schedules: Schedule[];
+  assignmentsByWeekday: AssignmentsByWeekday;
   onSelectDay: (date: Date) => void;
   substituteOn?: VertretungDay[];
 };
@@ -45,13 +48,12 @@ export function WeekGrid({
   selectedChildIds,
   events,
   schedules,
+  assignmentsByWeekday,
   onSelectDay,
   substituteOn = [],
 }: Props) {
   const monday = startOfWeekUtc(anchorDate);
   const days = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
-
-  const substituteChildIds = new Set(substituteOn.map((v) => v.childId));
 
   const colorFor = (childId: string | null | undefined) => {
     if (!childId) return "bg-rose-500/15 border-rose-400 text-rose-950";
@@ -139,11 +141,18 @@ export function WeekGrid({
               (selectedChildIds.length === 0 ||
                 (e.childId && selectedChildIds.includes(e.childId))),
           );
+          // Only the children this user actually covers on this weekday get a
+          // Stundenplan block. Substitute coverage is rendered separately as
+          // its own amber Vertretung block, so pure-substitute children are
+          // naturally excluded here (they aren't in the regular assignment).
+          const assignedToday = new Set(
+            childIdsForDate(assignmentsByWeekday, d),
+          );
           const daySchedules = schedules.filter(
             (s) =>
               s.weekday === wd &&
               selectedChildIds.includes(s.childId) &&
-              !substituteChildIds.has(s.childId),
+              assignedToday.has(s.childId),
           );
 
           return (


### PR DESCRIPTION
## Problem

On the homepage day view, the **"Stundenplan der Kinder"** card showed children a user wasn't actually on duty for that day (e.g. Anna saw both Lena *and* Max on a Wednesday; substitutes saw children too). Deleting/recreating the underlying schedule didn't help — it's a filtering bug, not bad data.

## Root cause

`tab-day.tsx` (and, identically, `week-grid.tsx`) filtered schedules only by `Schedule.weekday` **+ "is this child in my assigned set at all"** — never by *who I actually cover on this weekday*. Since every child has a schedule for every weekday and `assignedChildren` is the union across the whole range, every assigned child appeared every day. The page already computed `assignmentsByWeekday`, but it was never passed into `TabDay`/`WeekGrid`.

A separate, latent bug: the **seed wrote `weekday` as Mon=1…Fri=5** while the whole app uses **Mon=0…Fri=4** (`WEEKDAYS[0]="mon"`, `(getUTCDay()+6)%7`, admin calendar, Zod `min(0)`), shifting all seeded assignments/schedules by a day.

## Changes

**Bug fix**
- Gate `daySchedules` (day view) and `WeekGrid` blocks by `childIdsForDate(assignmentsByWeekday, date)` **or** today's substitute set — mirroring the existing `new-entry-sheet.tsx` pattern.
- Thread `assignmentsByWeekday` through `timesheet-shell` → `TabDay` / `TabWoche` → `WeekGrid`.

**Seed (`scripts/seed.ts`)**
- Convert all schedules/assignments to the Mon=0 convention.
- Remove all future-dated timesheet events (the UI cannot create future entries).
- **Add `ChildVertretung` seed data** — the substitute feature (#32) had none, so the Vertretung UI never rendered for seeded users. Copies the child's Stundenplan blocks exactly like `ChildrenFacade.createVertretung`.
- Realistic per-child schedules (fixes Mia's 09:00–14:00 assignment vs 13:00 schedule mismatch; splits Paul's Wednesday around his 11–12 therapy slot, exercising the multi-block model).
- Move illogical future workshop `attendedOn` dates into the past; drop the now-unused helper.

Two **future child-absences** are intentionally kept — the absence form allows future dates (announced upcoming absences), so they match the UI.

## Testing instructions

### Setup
1. `npm run db:seed` — ⚠️ runs `prisma migrate reset --force` and **wipes the dev DB**, then reseeds with the corrected data above.
2. `npm run dev` (or `npm run dev:local` if you need LAN/auth — open the printed IP, **not** `localhost`).
3. Log in with any seeded account, all password `password123`:
   - **Anna Schmidt** — `anna.schmidt@lebenshilfe.de` → Lena (**Mon/Wed/Fri**), Max (**Tue/Thu**)
   - **Ben Weber** — `ben.weber@lebenshilfe.de` → Mia (**Mon–Fri**)
   - **Clara Becker** — `clara.becker@lebenshilfe.de` → Paul (**Mon–Fri**)
   - **Admin** — `admin@lebenshilfe.de` · **Owner** — `owner@lebenshilfe.de`

### 1. Day view gating (the core fix)
As **Anna**, on the day (Tag) tab navigate the date:
- On a **Wednesday** the "Stundenplan der Kinder" card shows **only Lena** — Max must **not** appear.
- On a **Tuesday or Thursday** it shows **only Max** — Lena must **not** appear.
- On **Saturday/Sunday** the card is empty.

Before this fix both children showed on every weekday. ✅ = each day lists only the child Anna actually covers.

### 2. Week view gating
Switch to the week (Woche) tab as **Anna**. Each day column's Stundenplan block should match the assignment: Lena under Mon/Wed/Fri, Max under Tue/Thu — no child on a day they aren't covered.

### 3. Substitute / Vertretung coverage
The seed makes **Anna a substitute for Paul** (a recent past weekday) and **Clara a substitute for Max** (another recent past day).
- As **Anna**, navigate to her substitute day: **Paul** now appears (day view: in the Stundenplan list; week view: as a distinct **amber Vertretung block**), even though Paul is normally Clara's.
- On every other day Paul must **not** appear for Anna.
- Confirm the Vertretung UI now renders at all for seeded users (it was empty before, since #32 shipped no seed data).

### 4. Seed weekday convention (off-by-one fix)
Confirm assignments land on the intended weekday — e.g. Anna's Lena coverage appears on **Monday**, not Tuesday. Cross-check the **admin calendar / child-assignment view** (`admin@lebenshilfe.de`): seeded weekdays should line up exactly with what the per-user views show. Before the fix everything was shifted one day later.

### 5. Multi-block schedule (Paul's Wednesday split)
As **Clara**, on a **Wednesday**, Paul's Stundenplan shows **two blocks** — 08:00–11:00 and 12:00–13:00 — around the 11:00–12:00 therapy gap.

### 6. Mia time alignment
As **Ben**, Mia's schedule (08:00–14:00) and assignment (09:00–14:00) align cleanly — no mismatch artifacts.

### 7. No future timesheet entries
Browse forward from today in both day and week views: there should be **no timesheet events dated in the future**. (Two future *child-absences* are intentionally present and expected.)

## Automated checks
- `tsc --noEmit`, `eslint`, and `prettier --check` all pass.
- Seed not run in CI (`db:seed` does `migrate reset --force` and would wipe the dev DB) — run locally as in Setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
