### PR TITLE
feat(timesheet): derive Einsatz times from Stundenplan (COD-48)

### DIFF
--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -90,6 +90,7 @@ export function NewEntrySheet({
   const [childIds, setChildIds] = useState<string[]>(
     dayAssignedChildren.length === 1 ? [dayAssignedChildren[0].id] : [],
   );
+  const [selectedBlockIds, setSelectedBlockIds] = useState<string[]>([]);
   const [sigOpen, setSigOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
@@ -121,6 +122,12 @@ export function NewEntrySheet({
     );
   };
 
+  const toggleBlock = (id: string) => {
+    setSelectedBlockIds((cur) =>
+      cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id],
+    );
+  };
+
   const weekday = useMemo(() => weekdayIndex(parseIsoDate(date)), [date]);
 
   // The exact blocks that will be saved server-side: one entry per Stundenplan
@@ -142,6 +149,18 @@ export function NewEntrySheet({
     });
   }, [childIds, schedules, weekday, dayAssignedChildren]);
 
+  // Default to logging every block; the assistant unchecks the ones not
+  // worked. Re-runs only when the set of blocks changes (date/children), not
+  // when the assistant toggles a block, so manual choices stick.
+  useEffect(() => {
+    setSelectedBlockIds(scheduleBlocks.map((b) => b.id));
+  }, [scheduleBlocks]);
+
+  const selectedBlocks = useMemo(
+    () => scheduleBlocks.filter((b) => selectedBlockIds.includes(b.id)),
+    [scheduleBlocks, selectedBlockIds],
+  );
+
   // First names of selected children that have no Stundenplan on this weekday;
   // an entry can't be derived for them, so submission is blocked.
   const missingScheduleNames = useMemo(() => {
@@ -158,12 +177,12 @@ export function NewEntrySheet({
 
   const totalMinutes = useMemo(
     () =>
-      scheduleBlocks.reduce(
+      selectedBlocks.reduce(
         (sum, b) =>
           sum + (timeToMinutes(b.endTime) - timeToMinutes(b.startTime)),
         0,
       ),
-    [scheduleBlocks],
+    [selectedBlocks],
   );
 
   const canProceed =
@@ -171,23 +190,25 @@ export function NewEntrySheet({
       ? true
       : childIds.length >= 1 &&
         missingScheduleNames.length === 0 &&
-        scheduleBlocks.length >= 1;
+        selectedBlocks.length >= 1;
 
   const submitWithSignature = async (pngBase64: string) => {
     setSubmitting(true);
     try {
-      await createEventAction({
+      const result = await createEventAction({
         type,
         date,
         childIds: type === EventType.WORK ? childIds : [],
+        scheduleBlockIds:
+          type === EventType.WORK ? selectedBlockIds : undefined,
         note: note.trim() || undefined,
         signaturePngBase64: pngBase64,
       });
       toast.success(
         type === EventType.WORK
-          ? `Eintrag gespeichert (${childIds.length} Kind${
-              childIds.length === 1 ? "" : "er"
-            })`
+          ? `${result.createdCount} ${
+              result.createdCount === 1 ? "Eintrag" : "Einträge"
+            } gespeichert`
           : "Krankheit gespeichert",
       );
       setSigOpen(false);
@@ -201,8 +222,8 @@ export function NewEntrySheet({
 
   const signerSubtitle =
     type === EventType.WORK
-      ? `${date} · ${scheduleBlocks.length} ${
-          scheduleBlocks.length === 1 ? "Einsatz" : "Einsätze"
+      ? `${date} · ${selectedBlocks.length} ${
+          selectedBlocks.length === 1 ? "Einsatz" : "Einsätze"
         }${totalMinutes > 0 ? ` · ${formatMinutes(totalMinutes)}` : ""}`
       : `${date} · Krank · ganztägig`;
 
@@ -332,36 +353,49 @@ export function NewEntrySheet({
                       </p>
                     ) : (
                       <>
-                        <div className="space-y-1 rounded-lg border border-border bg-muted/40 p-2">
-                          {scheduleBlocks.map((b) => (
-                            <div
-                              key={b.id}
-                              className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm"
-                            >
-                              <span className="flex items-center gap-2">
+                        <div className="space-y-1 rounded-lg border border-border p-2">
+                          {scheduleBlocks.map((b) => {
+                            const checked = selectedBlockIds.includes(b.id);
+                            return (
+                              <label
+                                key={b.id}
+                                htmlFor={`block-${b.id}`}
+                                className={cn(
+                                  "flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors hover:bg-accent",
+                                  !checked && "opacity-55",
+                                )}
+                              >
+                                <Checkbox
+                                  id={`block-${b.id}`}
+                                  checked={checked}
+                                  onCheckedChange={() => toggleBlock(b.id)}
+                                />
                                 <Clock className="size-4 text-muted-foreground" />
                                 {childIds.length > 1 && (
                                   <span className="text-muted-foreground">
                                     {b.childFirstName}
                                   </span>
                                 )}
-                                <span className="font-mono tabular-nums text-base">
+                                <span className="font-mono text-base tabular-nums">
                                   {b.startTime}–{b.endTime}
                                 </span>
-                              </span>
-                              <span className="text-xs text-muted-foreground">
-                                {formatDuration(b.startTime, b.endTime)}
-                              </span>
-                            </div>
-                          ))}
+                                <span className="ml-auto text-xs text-muted-foreground">
+                                  {formatDuration(b.startTime, b.endTime)}
+                                </span>
+                              </label>
+                            );
+                          })}
                         </div>
                         <p className="text-xs text-muted-foreground">
-                          Die Zeiten kommen aus dem Stundenplan und sind nicht
-                          veränderbar
                           {scheduleBlocks.length > 1
-                            ? " — pro Block ein Eintrag."
-                            : "."}
+                            ? "Nur die tatsächlich gearbeiteten Blöcke auswählen — pro Block ein Eintrag. Die Zeiten kommen aus dem Stundenplan."
+                            : "Die Zeit kommt aus dem Stundenplan und ist nicht veränderbar."}
                         </p>
+                        {selectedBlocks.length === 0 && (
+                          <p className="text-xs font-medium text-amber-700">
+                            Mindestens einen Block auswählen.
+                          </p>
+                        )}
                       </>
                     )}
                   </div>

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Briefcase, Stethoscope, UserCheck } from "lucide-react";
+import { Briefcase, Clock, Stethoscope, UserCheck } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -29,18 +29,6 @@ import { childIdsForDate, type AssignmentsByWeekday } from "../weekday";
 import { cn, formatIsoDateUtc } from "@/lib/utils";
 import type { VertretungDay } from "./timesheet-shell";
 
-type LastEntry = {
-  startTime: string | null;
-  endTime: string | null;
-};
-
-type QuickSlot = {
-  key: string;
-  label: string;
-  start: string;
-  end: string;
-};
-
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -49,19 +37,22 @@ type Props = {
   assignmentsByWeekday: AssignmentsByWeekday;
   currentUserName: string;
   schedules: Schedule[];
-  lastEntry: LastEntry | null;
   /** Vertretung days for the current user — so substitute children appear in the form. */
   substituteOn?: VertretungDay[];
 };
 
-function addMinutes(time: string, minutes: number): string {
-  const total = Math.max(
-    0,
-    Math.min(24 * 60 - 1, timeToMinutes(time) + minutes),
-  );
+type ScheduleBlock = {
+  id: string;
+  childId: string;
+  childFirstName: string;
+  startTime: string;
+  endTime: string;
+};
+
+function formatMinutes(total: number): string {
   const h = Math.floor(total / 60);
   const m = total % 60;
-  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
 }
 
 export function NewEntrySheet({
@@ -72,13 +63,10 @@ export function NewEntrySheet({
   assignmentsByWeekday,
   currentUserName,
   schedules,
-  lastEntry,
   substituteOn = [],
 }: Props) {
   const [type, setType] = useState<EventType>(EventType.WORK);
   const [date, setDate] = useState(formatIsoDateUtc(defaultDate));
-  const [startTime, setStartTime] = useState("08:00");
-  const [endTime, setEndTime] = useState("17:00");
   const [note, setNote] = useState("");
 
   // Vertretungen for the currently selected date
@@ -109,8 +97,6 @@ export function NewEntrySheet({
     if (open) {
       setDate(formatIsoDateUtc(defaultDate));
       setType(EventType.WORK);
-      setStartTime("08:00");
-      setEndTime("17:00");
       setNote("");
     }
   }, [open, defaultDate]);
@@ -129,86 +115,63 @@ export function NewEntrySheet({
     });
   }, [dayAssignedChildren]);
 
-  const duration = useMemo(() => {
-    if (!startTime || !endTime) return null;
-    if (timeToMinutes(endTime) <= timeToMinutes(startTime)) return null;
-    return formatDuration(startTime, endTime);
-  }, [startTime, endTime]);
-
-  const canProceed =
-    type === EventType.SICK ? true : childIds.length >= 1 && Boolean(duration);
-
   const toggleChild = (id: string) => {
     setChildIds((cur) =>
       cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id],
     );
   };
 
-  const quickSlots = useMemo<QuickSlot[]>(() => {
-    const out: QuickSlot[] = [];
-    const seen = new Set<string>();
-    const push = (slot: QuickSlot) => {
-      const fp = `${slot.start}-${slot.end}`;
-      if (seen.has(fp)) return;
-      seen.add(fp);
-      out.push(slot);
-    };
+  const weekday = useMemo(() => weekdayIndex(parseIsoDate(date)), [date]);
 
-    // Vertretung time slot(s) — shown first so the substitute can quickly confirm
-    for (const v of dayVertretungen) {
-      push({
-        key: `vertretung-${v.childId}`,
-        label: `Vertretung (${v.childName.split(" ")[0]})`,
-        start: v.startTime,
-        end: v.endTime,
-      });
-    }
+  // The exact blocks that will be saved server-side: one entry per Stundenplan
+  // block per selected child. Times are read-only — they come from the
+  // Stundenplan, never from manual input (COD-48).
+  const scheduleBlocks = useMemo<ScheduleBlock[]>(() => {
+    return childIds.flatMap((childId) => {
+      const child = dayAssignedChildren.find((c) => c.id === childId);
+      return schedules
+        .filter((s) => s.childId === childId && s.weekday === weekday)
+        .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))
+        .map((s) => ({
+          id: s.id,
+          childId,
+          childFirstName: child?.firstName ?? "",
+          startTime: s.startTime,
+          endTime: s.endTime,
+        }));
+    });
+  }, [childIds, schedules, weekday, dayAssignedChildren]);
 
-    const wd = weekdayIndex(parseIsoDate(date));
-    const relevantChildIds =
-      childIds.length > 0 ? childIds : dayAssignedChildren.map((c) => c.id);
-    const daySchedules = schedules.filter(
-      (s) => s.weekday === wd && relevantChildIds.includes(s.childId),
-    );
-    if (daySchedules.length > 0) {
-      const start = daySchedules.reduce((acc, s) =>
-        timeToMinutes(s.startTime) < timeToMinutes(acc.startTime) ? s : acc,
-      ).startTime;
-      const end = daySchedules.reduce((acc, s) =>
-        timeToMinutes(s.endTime) > timeToMinutes(acc.endTime) ? s : acc,
-      ).endTime;
-      push({
-        key: "schedule",
-        label: "Stundenplan",
-        start,
-        end,
-      });
-    }
+  // First names of selected children that have no Stundenplan on this weekday;
+  // an entry can't be derived for them, so submission is blocked.
+  const missingScheduleNames = useMemo(() => {
+    return childIds
+      .filter(
+        (id) =>
+          !schedules.some((s) => s.childId === id && s.weekday === weekday),
+      )
+      .map(
+        (id) => dayAssignedChildren.find((c) => c.id === id)?.firstName ?? "",
+      )
+      .filter(Boolean);
+  }, [childIds, schedules, weekday, dayAssignedChildren]);
 
-    if (lastEntry?.startTime && lastEntry?.endTime) {
-      push({
-        key: "last",
-        label: "Letzter Eintrag",
-        start: lastEntry.startTime,
-        end: lastEntry.endTime,
-      });
-      push({
-        key: "last-plus-15",
-        label: "Letzter +15m",
-        start: lastEntry.startTime,
-        end: addMinutes(lastEntry.endTime, 15),
-      });
-    }
+  const totalMinutes = useMemo(
+    () =>
+      scheduleBlocks.reduce(
+        (sum, b) =>
+          sum + (timeToMinutes(b.endTime) - timeToMinutes(b.startTime)),
+        0,
+      ),
+    [scheduleBlocks],
+  );
 
-    return out;
-  }, [
-    date,
-    schedules,
-    dayAssignedChildren,
-    childIds,
-    lastEntry,
-    dayVertretungen,
-  ]);
+  const canProceed =
+    type === EventType.SICK
+      ? true
+      : childIds.length >= 1 &&
+        missingScheduleNames.length === 0 &&
+        scheduleBlocks.length >= 1;
 
   const submitWithSignature = async (pngBase64: string) => {
     setSubmitting(true);
@@ -217,8 +180,6 @@ export function NewEntrySheet({
         type,
         date,
         childIds: type === EventType.WORK ? childIds : [],
-        startTime: type === EventType.WORK ? startTime : undefined,
-        endTime: type === EventType.WORK ? endTime : undefined,
         note: note.trim() || undefined,
         signaturePngBase64: pngBase64,
       });
@@ -240,7 +201,9 @@ export function NewEntrySheet({
 
   const signerSubtitle =
     type === EventType.WORK
-      ? `${date} · ${startTime}–${endTime}${duration ? ` · ${duration}` : ""}`
+      ? `${date} · ${scheduleBlocks.length} ${
+          scheduleBlocks.length === 1 ? "Einsatz" : "Einsätze"
+        }${totalMinutes > 0 ? ` · ${formatMinutes(totalMinutes)}` : ""}`
       : `${date} · Krank · ganztägig`;
 
   return (
@@ -358,59 +321,49 @@ export function NewEntrySheet({
                   </div>
                 )}
 
-                <div className="grid grid-cols-[1fr_auto_1fr] gap-2 items-end">
+                {childIds.length > 0 && (
                   <div className="space-y-1.5">
-                    <Label htmlFor="start">Start</Label>
-                    <Input
-                      id="start"
-                      type="time"
-                      value={startTime}
-                      onChange={(e) => setStartTime(e.target.value)}
-                      className="h-14 text-xl font-mono tabular-nums"
-                    />
-                  </div>
-                  <span className="pb-3 text-muted-foreground">→</span>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="end">Ende</Label>
-                    <Input
-                      id="end"
-                      type="time"
-                      value={endTime}
-                      onChange={(e) => setEndTime(e.target.value)}
-                      className="h-14 text-xl font-mono tabular-nums"
-                    />
-                  </div>
-                </div>
-
-                <p className="text-sm text-muted-foreground">
-                  {duration
-                    ? `Dauer: ${duration}`
-                    : "Ende muss nach Start liegen"}
-                </p>
-
-                {quickSlots.length > 0 && (
-                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-3">
-                    {quickSlots.map((slot) => (
-                      <button
-                        key={slot.key}
-                        type="button"
-                        onClick={() => {
-                          setStartTime(slot.start);
-                          setEndTime(slot.end);
-                        }}
-                        className={cn(
-                          "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors",
-                          startTime === slot.start && endTime === slot.end
-                            ? "border-amber-400 bg-amber-400/10 text-foreground"
-                            : "border-border bg-muted/40 hover:bg-accent",
-                        )}
-                      >
-                        <span className="font-medium">{slot.label}</span>
-                        <span className="font-mono tabular-nums text-muted-foreground">
-                          {slot.start}–{slot.end}
-                        </span>
-                      </button>
-                    ))}
+                    <Label>Zeiten (aus Stundenplan)</Label>
+                    {missingScheduleNames.length > 0 ? (
+                      <p className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                        Für {missingScheduleNames.join(", ")} ist an diesem Tag
+                        kein Stundenplan hinterlegt. Ein Eintrag ist nur entlang
+                        des Stundenplans möglich.
+                      </p>
+                    ) : (
+                      <>
+                        <div className="space-y-1 rounded-lg border border-border bg-muted/40 p-2">
+                          {scheduleBlocks.map((b) => (
+                            <div
+                              key={b.id}
+                              className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm"
+                            >
+                              <span className="flex items-center gap-2">
+                                <Clock className="size-4 text-muted-foreground" />
+                                {childIds.length > 1 && (
+                                  <span className="text-muted-foreground">
+                                    {b.childFirstName}
+                                  </span>
+                                )}
+                                <span className="font-mono tabular-nums text-base">
+                                  {b.startTime}–{b.endTime}
+                                </span>
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {formatDuration(b.startTime, b.endTime)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          Die Zeiten kommen aus dem Stundenplan und sind nicht
+                          veränderbar
+                          {scheduleBlocks.length > 1
+                            ? " — pro Block ein Eintrag."
+                            : "."}
+                        </p>
+                      </>
+                    )}
                   </div>
                 )}
               </>

--- a/src/features/timesheet/components/timesheet-shell.tsx
+++ b/src/features/timesheet/components/timesheet-shell.tsx
@@ -136,17 +136,6 @@ export function SchoolAssistantApp({
     setActiveTab(id);
   };
 
-  const lastWorkEntry = useMemo(() => {
-    const work = events.filter(
-      (e) => e.type === "WORK" && e.startTime && e.endTime,
-    );
-    if (work.length === 0) return null;
-    const sorted = [...work].sort(
-      (a, b) => b.date.getTime() - a.date.getTime(),
-    );
-    return sorted[0];
-  }, [events]);
-
   // Work entries an admin created or edited on the Schulbegleiter's behalf are
   // stored without a signatureKey. They await the Schulbegleiter's confirming
   // signature (soft-deleted originals are already filtered server-side).
@@ -366,14 +355,6 @@ export function SchoolAssistantApp({
           currentUserName={currentUser.name}
           schedules={schedules}
           substituteOn={substituteOn}
-          lastEntry={
-            lastWorkEntry
-              ? {
-                  startTime: lastWorkEntry.startTime ?? null,
-                  endTime: lastWorkEntry.endTime ?? null,
-                }
-              : null
-          }
         />
 
         <SettingsDialog

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -41,17 +41,32 @@ function parseDateOnly(dateStr: string): Date {
 // blocks on a day, each becoming its own entry. Throws if any selected child
 // has no schedule for that weekday: a Schulbegleiter may only log time that
 // exists in the Stundenplan (the substitute/Vertretung case is COD-51).
-async function deriveWorkBlocksFromSchedule(childIds: string[], date: Date) {
+//
+// `selectedBlockIds` lets the assistant pick which of the day's blocks were
+// actually worked. The selection only narrows WHICH blocks are logged — the
+// times always come from the Schedule, never from the client. When omitted,
+// every block is logged (full day).
+async function deriveWorkBlocksFromSchedule(
+  childIds: string[],
+  date: Date,
+  selectedBlockIds?: string[],
+) {
   const weekday = weekdayIndex(date);
   const schedules = await getSchedulesForChildren(childIds);
 
-  const blocks: { childId: string; startTime: string; endTime: string }[] = [];
+  const available: {
+    id: string;
+    childId: string;
+    startTime: string;
+    endTime: string;
+  }[] = [];
   const childrenWithoutSchedule: string[] = [];
 
   for (const childId of childIds) {
     const childBlocks = schedules
       .filter((s) => s.childId === childId && s.weekday === weekday)
       .map((s) => ({
+        id: s.id,
         childId,
         startTime: s.startTime,
         endTime: s.endTime,
@@ -60,7 +75,7 @@ async function deriveWorkBlocksFromSchedule(childIds: string[], date: Date) {
       childrenWithoutSchedule.push(childId);
       continue;
     }
-    blocks.push(...childBlocks);
+    available.push(...childBlocks);
   }
 
   if (childrenWithoutSchedule.length > 0) {
@@ -69,7 +84,23 @@ async function deriveWorkBlocksFromSchedule(childIds: string[], date: Date) {
     );
   }
 
-  return blocks;
+  // No explicit selection → log the full day's blocks.
+  if (selectedBlockIds === undefined) return available;
+
+  if (selectedBlockIds.length === 0) {
+    throw new Error("Es wurde keine Stundenplan-Zeit ausgewählt.");
+  }
+
+  // Resolve each picked id back to a real schedule block. An id that isn't an
+  // available block (wrong child, wrong day, tampered) is rejected outright.
+  const byId = new Map(available.map((b) => [b.id, b]));
+  return selectedBlockIds.map((id) => {
+    const block = byId.get(id);
+    if (!block) {
+      throw new Error("Ungültige Stundenplan-Auswahl.");
+    }
+    return block;
+  });
 }
 
 function assertMonthNotLocked(
@@ -145,9 +176,13 @@ export const TimesheetFacade = {
     assertMonthNotLocked(report);
 
     if (parsed.type === "WORK") {
-      // Derive times before touching storage so a missing Stundenplan fails
-      // fast without leaving an orphaned signature behind.
-      const blocks = await deriveWorkBlocksFromSchedule(parsed.childIds, date);
+      // Derive times before touching storage so a missing Stundenplan (or an
+      // invalid selection) fails fast without leaving an orphaned signature.
+      const blocks = await deriveWorkBlocksFromSchedule(
+        parsed.childIds,
+        date,
+        parsed.scheduleBlockIds,
+      );
 
       const batchId = randomUUID();
       const signatureKey = `signatures/events/${userId}/${batchId}.png`;

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { weekdayIndex } from "@/lib/dates";
 import {
   ConfirmWorkEventsSchema,
   CreateEventSchema,
@@ -33,6 +34,42 @@ function parseDateOnly(dateStr: string): Date {
   // "YYYY-MM-DD" -> UTC date (matches @db.Date semantics without TZ shift)
   const [y, m, d] = dateStr.split("-").map(Number);
   return new Date(Date.UTC(y, m - 1, d));
+}
+
+// COD-48: derive WORK start/end times from each child's Stundenplan for the
+// entry's weekday — one block per Schedule row. A child may have several
+// blocks on a day, each becoming its own entry. Throws if any selected child
+// has no schedule for that weekday: a Schulbegleiter may only log time that
+// exists in the Stundenplan (the substitute/Vertretung case is COD-51).
+async function deriveWorkBlocksFromSchedule(childIds: string[], date: Date) {
+  const weekday = weekdayIndex(date);
+  const schedules = await getSchedulesForChildren(childIds);
+
+  const blocks: { childId: string; startTime: string; endTime: string }[] = [];
+  const childrenWithoutSchedule: string[] = [];
+
+  for (const childId of childIds) {
+    const childBlocks = schedules
+      .filter((s) => s.childId === childId && s.weekday === weekday)
+      .map((s) => ({
+        childId,
+        startTime: s.startTime,
+        endTime: s.endTime,
+      }));
+    if (childBlocks.length === 0) {
+      childrenWithoutSchedule.push(childId);
+      continue;
+    }
+    blocks.push(...childBlocks);
+  }
+
+  if (childrenWithoutSchedule.length > 0) {
+    throw new Error(
+      "Für mindestens ein ausgewähltes Kind ist an diesem Tag kein Stundenplan hinterlegt. Ein Eintrag ist nur entlang des Stundenplans möglich.",
+    );
+  }
+
+  return blocks;
 }
 
 function assertMonthNotLocked(
@@ -108,19 +145,21 @@ export const TimesheetFacade = {
     assertMonthNotLocked(report);
 
     if (parsed.type === "WORK") {
+      // Derive times before touching storage so a missing Stundenplan fails
+      // fast without leaving an orphaned signature behind.
+      const blocks = await deriveWorkBlocksFromSchedule(parsed.childIds, date);
+
       const batchId = randomUUID();
       const signatureKey = `signatures/events/${userId}/${batchId}.png`;
       await uploadSignature(signatureKey, parsed.signaturePngBase64);
       await insertWorkEvents({
         userId,
-        childIds: parsed.childIds,
         date,
-        startTime: parsed.startTime!,
-        endTime: parsed.endTime!,
+        blocks,
         note: parsed.note ?? null,
         signatureKey,
       });
-      return { createdCount: parsed.childIds.length, signatureKey };
+      return { createdCount: blocks.length, signatureKey };
     }
 
     const eventId = randomUUID();

--- a/src/features/timesheet/schemas.ts
+++ b/src/features/timesheet/schemas.ts
@@ -15,13 +15,14 @@ const signatureSchema = z
     "Ungültige Signatur.",
   );
 
+// Times are NOT supplied by the client for WORK entries (COD-48): a
+// Schulbegleiter follows the Stundenplan, so start/end are derived
+// server-side from the child's Schedule for the entry's weekday.
 export const CreateEventSchema = z
   .object({
     type: z.nativeEnum(EventType),
     date: dateStringSchema,
     childIds: z.array(z.string().min(1)).default([]),
-    startTime: timeStringSchema.optional(),
-    endTime: timeStringSchema.optional(),
     note: z.string().max(2000).optional(),
     signaturePngBase64: signatureSchema,
   })
@@ -33,24 +34,6 @@ export const CreateEventSchema = z
           path: ["childIds"],
           message: "Mindestens ein Kind auswählen.",
         });
-      if (!val.startTime)
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["startTime"],
-          message: "Startzeit fehlt.",
-        });
-      if (!val.endTime)
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["endTime"],
-          message: "Endzeit fehlt.",
-        });
-      if (val.startTime && val.endTime && !(val.endTime > val.startTime))
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["endTime"],
-          message: "Ende muss nach Start liegen.",
-        });
     }
     if (val.type === "SICK") {
       if (val.childIds.length !== 0)
@@ -58,12 +41,6 @@ export const CreateEventSchema = z
           code: z.ZodIssueCode.custom,
           path: ["childIds"],
           message: "Bei Krankheit darf kein Kind gewählt werden.",
-        });
-      if (val.startTime || val.endTime)
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["startTime"],
-          message: "Krankheit ist ganztägig.",
         });
     }
   });

--- a/src/features/timesheet/schemas.ts
+++ b/src/features/timesheet/schemas.ts
@@ -17,12 +17,15 @@ const signatureSchema = z
 
 // Times are NOT supplied by the client for WORK entries (COD-48): a
 // Schulbegleiter follows the Stundenplan, so start/end are derived
-// server-side from the child's Schedule for the entry's weekday.
+// server-side from the child's Schedule for the entry's weekday. The client
+// only chooses WHICH Stundenplan blocks were actually worked, by Schedule
+// row id; the times themselves are always resolved from the schedule.
 export const CreateEventSchema = z
   .object({
     type: z.nativeEnum(EventType),
     date: dateStringSchema,
     childIds: z.array(z.string().min(1)).default([]),
+    scheduleBlockIds: z.array(z.string().min(1)).optional(),
     note: z.string().max(2000).optional(),
     signaturePngBase64: signatureSchema,
   })

--- a/src/features/timesheet/services/index.ts
+++ b/src/features/timesheet/services/index.ts
@@ -80,23 +80,23 @@ export async function getEventsForUserInMonth(
   return getEventsForUserInRange(userId, start, end);
 }
 
+// One Event row per (child, Stundenplan block). A child with several schedule
+// blocks on the day therefore produces several WORK entries (COD-48).
 export async function insertWorkEvents(args: {
   userId: string;
-  childIds: string[];
   date: Date;
-  startTime: string;
-  endTime: string;
+  blocks: { childId: string; startTime: string; endTime: string }[];
   note?: string | null;
   signatureKey: string;
 }) {
   return prisma.event.createMany({
-    data: args.childIds.map((childId) => ({
+    data: args.blocks.map((block) => ({
       userId: args.userId,
-      childId,
+      childId: block.childId,
       type: EventType.WORK,
       date: args.date,
-      startTime: args.startTime,
-      endTime: args.endTime,
+      startTime: block.startTime,
+      endTime: block.endTime,
       note: args.note ?? null,
       signatureKey: args.signatureKey,
     })),


### PR DESCRIPTION
## COD-48 — Einsatz-Eintrag: Zeitauswahl entfernen, Zeit aus Stundenplan ableiten

Closes COD-48 (duplicate of COD-45).

Schulbegleiter should always follow the Stundenplan, so the manual **time picker** in the WORK ("direkte Leistung") entry is removed. Start/end times are derived from the child's `Schedule` for the entry's weekday. The assistant can still **choose which of the day's Stundenplan blocks they actually worked** — but only *which* blocks, never the times themselves.

### What changed
- **`schemas.ts`** — `CreateEventSchema` no longer accepts `startTime`/`endTime`. It now accepts an optional `scheduleBlockIds` (the selected `Schedule` row ids); times are never client-supplied.
- **`facade.ts`** — `TimesheetFacade.createEvent` derives one block per `Schedule` row per child for the weekday, then narrows to the selected `scheduleBlockIds`. It **blocks** the entry if any selected child has no Stundenplan that weekday, rejects ids that aren't real blocks for those children, and requires a non-empty selection. Derivation runs before the signature upload so failures don't orphan a signature. **One `Event` per (child, block).**
- **`services/index.ts`** — `insertWorkEvents` inserts one `Event` row per `(child, block)`.
- **`new-entry-sheet.tsx`** — removed the time picker + quick-slots (and the now-unused `lastEntry` prop). The day's Stundenplan blocks are shown as **checkboxes, all pre-selected**; the assistant unchecks any block they didn't work. Submit is disabled when a selected child has no Stundenplan, or when no block is selected.
- **`timesheet-shell.tsx`** — dropped the `lastWorkEntry`/`lastEntry` wiring that only fed the removed quick-slots.

### Decisions (confirmed with product)
- **Multiple blocks → one entry per block**, and the assistant **picks which blocks** they worked (all pre-selected by default).
- **Whole blocks only** — times come from the Stundenplan and are not editable; selection only chooses which blocks.
- **Per-(child, block) toggles** when several children are selected.
- **No Stundenplan for the day → block the entry** for an assigned child (consistent with "an entry must never be longer than the Stundenplan"). Vertretung entries for unassigned students are deferred to **COD-51**.
- **Times shown read-only** (reconciles COD-48 "no time picker" with COD-45 "vorausgefüllt & nicht veränderbar").
- **Scope = WORK only.** SICK stays time-less; indirect/Zusatzleistung is untouched and owned by **COD-30**. The ±15 min billing convention is **not** added here.

### Notes / boundaries
- Times stay authoritative on the server: the client sends Schedule-row ids and the facade resolves the times, so a tampered/extra id is rejected.
- Substitute (Vertretung) entries use the same form. Vertretung blocks are created from and synced to the Stundenplan, so deriving from `Schedule` yields the same times. A Vertretung created via the legacy whole-day fallback (child with no Stundenplan) is now blocked — consistent with the policy and the COD-51 follow-up.
- Admin-created entries use a separate schema/path and are unaffected.

### Verification
- `npx tsc --noEmit` → clean
- `npm run lint` (incl. `eslint-plugin-boundaries`) → clean
- `npm run format:check` → clean
- `npm run build` → success

## Manual testing instructions

Setup: `npm run db:seed` (seeds children with Stundenplan blocks + assignments), then `npm run dev` (or `npm run dev:local`) and log in as a **Schulbegleiter**.

1. **Single child, single block**
   - Open **Neuer Eintrag**, pick a date where you're assigned to exactly one child with one Stundenplan block that weekday.
   - Expect: **no time picker**. A "Zeiten (aus Stundenplan)" box shows the single block, pre-checked, with its time + duration; times are not editable.
   - Sign & save → toast "1 Eintrag gespeichert"; the entry shows the schedule time in Tag/Woche.

2. **Single child, multiple blocks → selectable**
   - Use a child with ≥2 Stundenplan blocks that weekday (e.g. 08:00–10:00 and 11:00–13:00).
   - Expect: **all blocks pre-checked**. Uncheck one → it dims; the signature subtitle’s count + total duration update. Save → **one entry per checked block** only (the unchecked block is not logged). Toast count matches.
   - Uncheck **all** blocks → "Mindestens einen Block auswählen." and **Save disabled**.

3. **Multiple children, mixed blocks**
   - Pick a day with several assigned children; select two or more.
   - Expect: each block is listed with the child's first name and its own checkbox, all pre-checked. Uncheck blocks independently across children → saving creates one entry per remaining checked (child, block), all with the same signature.

4. **No Stundenplan → blocked**
   - Pick/keep a selected child with no Stundenplan that weekday (admin can remove the child's blocks for that weekday).
   - Expect: amber warning ("…kein Stundenplan hinterlegt…") and **Save disabled**. Server safety net: the action throws "Für mindestens ein ausgewähltes Kind ist an diesem Tag kein Stundenplan hinterlegt."

5. **Krank (SICK) unchanged**
   - Switch to **Krank**: no child, no time/block UI; saving still works as before.

6. **Substitute (Vertretung)**
   - As a user covering a Vertretung, confirm the substitute child appears, the listed blocks match the child's Stundenplan, selection works, and saving succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
