### PR TITLE
COD-50: (Admin) Übersicht problematischer Fälle (Handlungsbedarf)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,3 +48,30 @@ src/
 ## Manifesto Rules
 - **Deep-linking into a feature's `/services` folder is a build-breaking offense.**
 - **Every Feature MUST expose its logic through a single `facade.ts`.**
+
+## Feature Notes
+
+### Handlungsbedarf dashboard (COD-50)
+`/admin/handlungsbedarf` surfaces problematic cases for a selectable week
+(sick Schulbegleiter without a Vertretung, sick substitutes, abated children
+who still have a booked Einsatz, unstaffed Stundenplan blocks, booked hours
+over the Stundenplan, and missing Stammdaten such as the
+Schweigepflichtsentbindung).
+
+It lives **inside the `children` feature** rather than in a Use Case: every
+input is reachable from the children domain (children with their assignments,
+Stundenplan, absences and Vertretungen, plus the `Event` rows the children
+services already own), so it is a single-feature operation. Per the rules, a
+single-feature operation is **not** a Use Case.
+
+- **Detection** is a pure, side-effect-free function in
+  `features/children/handlungsbedarf.ts` (`detectHandlungsbedarf`). It takes
+  already-serialized data and returns a sorted list of cases — trivially
+  testable, no DB/session.
+- **Facade**: `ChildrenFacade.getHandlungsbedarf(weekStartIso)` fetches the data
+  via the children services and delegates to the pure detector.
+- **Action**: `getHandlungsbedarfAction` (`requireAdmin` → Facade) feeds the
+  client week-switcher; the inline "Vertretung zuweisen" reuses the existing
+  `createVertretungAction` / `updateVertretungAction`.
+
+See `docs/architecture/dependency-graph.md` for the diagram.

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -1,0 +1,71 @@
+# Dependency Graph
+
+Per `AGENTS.md`, this diagram tracks **which Use Cases call which Feature
+Facades**. Use Cases are the only place cross-feature coordination is allowed;
+single-feature work is performed by an Action calling its Facade directly and
+therefore does **not** appear as a Use Case node below.
+
+```mermaid
+graph TD
+    subgraph "Use Cases (cross-feature orchestrators)"
+        UC_cancelInvite[cancel-admin-invitation]
+        UC_createSA[create-school-assistant]
+        UC_createEvent[create-timesheet-event]
+        UC_fetchInvite[fetch-invite-details]
+        UC_getChildren[get-assigned-children]
+        UC_inviteAdmin[invite-admin-user]
+        UC_promote[promote-user-to-owner]
+        UC_removeAdmin[remove-admin-user]
+        UC_resendAdmin[resend-admin-invitation]
+        UC_resendSA[resend-school-assistant-invitation]
+    end
+
+    subgraph "Feature Facades"
+        F_children[ChildrenFacade]
+        F_timesheet[TimesheetFacade]
+        F_sa[SchoolAssistantsFacade]
+        F_invitation[InvitationFacade]
+        F_user[UserFacade]
+    end
+
+    UC_cancelInvite --> F_invitation
+    UC_createSA --> F_invitation
+    UC_createSA --> F_sa
+    UC_createEvent --> F_children
+    UC_createEvent --> F_timesheet
+    UC_fetchInvite --> F_invitation
+    UC_fetchInvite --> F_sa
+    UC_getChildren --> F_children
+    UC_getChildren --> F_timesheet
+    UC_inviteAdmin --> F_invitation
+    UC_inviteAdmin --> F_user
+    UC_promote --> F_user
+    UC_removeAdmin --> F_user
+    UC_resendAdmin --> F_invitation
+    UC_resendSA --> F_invitation
+    UC_resendSA --> F_sa
+```
+
+## Single-feature flows (no Use Case)
+
+These Actions call exactly one Facade and so, per the architecture rules, are
+**not** Use Cases. They are listed here for completeness.
+
+- **Handlungsbedarf dashboard** (COD-50) — `/admin/handlungsbedarf`.
+  `getHandlungsbedarfAction` → `ChildrenFacade.getHandlungsbedarf()`. The facade
+  loads all children (with assignments, Stundenplan, absences, Vertretungen)
+  plus the week's `SICK`/`WORK` events from the children services, then runs the
+  pure `detectHandlungsbedarf()` rules. The inline "Vertretung zuweisen" action
+  reuses `createVertretungAction` / `updateVertretungAction` from the same
+  feature.
+
+  ```mermaid
+  graph LR
+      Page["/admin/handlungsbedarf (page + action)"] --> F_children[ChildrenFacade]
+      F_children --> S_children[children/services]
+  ```
+
+  All required data lives in (or is reachable through) the `children` feature,
+  so a cross-feature Use Case is intentionally avoided. The list of accepted
+  Schulbegleiter for the assign combobox is fetched separately on the page via
+  `SchoolAssistantsFacade.list()` (read-only options, not part of detection).

--- a/src/app/admin/_components/nav-items.ts
+++ b/src/app/admin/_components/nav-items.ts
@@ -3,6 +3,7 @@ import {
   BookOpen,
   Home,
   ShieldCheck,
+  TriangleAlert,
   Users,
   type LucideIcon,
 } from "lucide-react";
@@ -20,6 +21,12 @@ export const NAV_ITEMS: readonly NavItem[] = [
     label: "Übersicht",
     description: "Zurück zur Übersicht.",
     icon: Home,
+  },
+  {
+    href: "/admin/handlungsbedarf",
+    label: "Handlungsbedarf",
+    description: "Problematische Fälle und offene Vertretungen.",
+    icon: TriangleAlert,
   },
   {
     href: "/admin/school-assistants",

--- a/src/app/admin/handlungsbedarf/page.tsx
+++ b/src/app/admin/handlungsbedarf/page.tsx
@@ -1,0 +1,27 @@
+import { ChildrenFacade, HandlungsbedarfDashboard } from "@/features/children";
+import { SchoolAssistantsFacade } from "@/features/school-assistants";
+import { parseIsoDate, startOfWeekUtc, todayIsoBerlin } from "@/lib/dates";
+import { formatIsoDateUtc } from "@/lib/utils";
+
+export default async function HandlungsbedarfPage() {
+  // Default to the current ISO week (Monday), evaluated in Europe/Berlin so the
+  // server doesn't drift onto the wrong week late in the evening.
+  const weekStartIso = formatIsoDateUtc(
+    startOfWeekUtc(parseIsoDate(todayIsoBerlin())),
+  );
+
+  const [result, schoolAssistants] = await Promise.all([
+    ChildrenFacade.getHandlungsbedarf(weekStartIso),
+    SchoolAssistantsFacade.list(),
+  ]);
+
+  return (
+    <HandlungsbedarfDashboard
+      initialResult={result}
+      initialWeekStartIso={weekStartIso}
+      schoolAssistantOptions={schoolAssistants
+        .filter((p) => !!p.userId)
+        .map((p) => ({ id: p.userId as string, name: p.name }))}
+    />
+  );
+}

--- a/src/features/children/actions.ts
+++ b/src/features/children/actions.ts
@@ -198,3 +198,10 @@ export async function deleteVertretungAction(childId: string, date: string) {
   revalidatePath(ROUTE);
   return { success: true as const };
 }
+
+// COD-50 — read-only fetch of the Handlungsbedarf cases for a given week.
+// Called from the dashboard when the admin switches weeks.
+export async function getHandlungsbedarfAction(weekStartIso: string) {
+  await requireAdmin();
+  return ChildrenFacade.getHandlungsbedarf(weekStartIso);
+}

--- a/src/features/children/components/handlungsbedarf/assign-vertretung-dialog.tsx
+++ b/src/features/children/components/handlungsbedarf/assign-vertretung-dialog.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { UserCog } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { formatDate } from "@/lib/utils";
+
+import {
+  SchoolAssistantCombobox,
+  type SchoolAssistantOption,
+} from "../calendar/school-assistant-combobox";
+import { createVertretungAction, updateVertretungAction } from "../../actions";
+import type { VertretungAssignTarget } from "../../handlungsbedarf";
+
+type Props = {
+  target: VertretungAssignTarget;
+  schoolAssistantOptions: SchoolAssistantOption[];
+  /** Called after a successful save so the dashboard can reload the week. */
+  onResolved?: () => void;
+};
+
+/**
+ * Inline "Vertretung zuweisen" / "Vertretung ändern" action used by the
+ * Handlungsbedarf dashboard. Creates a new Vertretung when none exists yet,
+ * or swaps the substitute when one is already in place (e.g. the substitute
+ * itself fell sick). Times always mirror the Stundenplan — see the facade.
+ */
+export function AssignVertretungDialog({
+  target,
+  schoolAssistantOptions,
+  onResolved,
+}: Props) {
+  const isReassign = target.currentSubstituteUserId != null;
+  const [open, setOpen] = useState(false);
+  const [substituteUserId, setSubstituteUserId] = useState<string | null>(
+    target.currentSubstituteUserId,
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSave() {
+    if (!substituteUserId) {
+      setError("Bitte einen Schulbegleiter als Vertretung wählen.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      if (isReassign) {
+        await updateVertretungAction(target.childId, target.date, {
+          substituteUserId,
+        });
+      } else {
+        await createVertretungAction({
+          childId: target.childId,
+          substituteUserId,
+          date: target.date,
+        });
+      }
+      toast.success("Vertretung gespeichert.");
+      setOpen(false);
+      onResolved?.();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Speichern fehlgeschlagen.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant={isReassign ? "outline" : "default"}
+        className="w-full sm:w-auto"
+        onClick={() => {
+          setSubstituteUserId(target.currentSubstituteUserId);
+          setError(null);
+          setOpen(true);
+        }}
+      >
+        <UserCog />
+        {isReassign ? "Vertretung ändern" : "Vertretung zuweisen"}
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={setOpen}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {isReassign ? "Vertretung ändern" : "Vertretung zuweisen"}
+            </DialogTitle>
+            <DialogDescription>
+              {target.childName} · {formatDate(target.date)}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">Vertreter</Label>
+              <SchoolAssistantCombobox
+                options={schoolAssistantOptions}
+                value={substituteUserId}
+                onChange={setSubstituteUserId}
+                placeholder="Wer vertritt?"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Zeit: {target.scheduleLabel} (laut Stundenplan)
+            </p>
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              disabled={busy}
+            >
+              Abbrechen
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={busy}
+            >
+              {busy ? "Speichert…" : "Speichern"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/children/components/handlungsbedarf/handlungsbedarf-dashboard.tsx
+++ b/src/features/children/components/handlungsbedarf/handlungsbedarf-dashboard.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  ChevronLeft,
+  ChevronRight,
+  CircleAlert,
+  CircleCheck,
+  Info,
+  TriangleAlert,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  cn,
+  formatIsoDateLocal,
+  formatShortDateWithWeekday,
+} from "@/lib/utils";
+
+import {
+  addDays,
+  germanWeekRangeLabel,
+  startOfWeekMonday,
+} from "../calendar/week-utils";
+import type { SchoolAssistantOption } from "../calendar/school-assistant-combobox";
+import { getHandlungsbedarfAction } from "../../actions";
+import type {
+  HandlungsbedarfCase,
+  HandlungsbedarfCategory,
+  HandlungsbedarfResult,
+  HandlungsbedarfSeverity,
+} from "../../handlungsbedarf";
+import { AssignVertretungDialog } from "./assign-vertretung-dialog";
+
+type Props = {
+  initialResult: HandlungsbedarfResult;
+  initialWeekStartIso: string;
+  schoolAssistantOptions: SchoolAssistantOption[];
+};
+
+const SEVERITY_META: Record<
+  HandlungsbedarfSeverity,
+  { Icon: LucideIcon; iconClass: string; cardClass: string }
+> = {
+  critical: {
+    Icon: TriangleAlert,
+    iconClass: "text-red-600 dark:text-red-400",
+    cardClass: "border-red-500/40 bg-red-500/5",
+  },
+  warning: {
+    Icon: CircleAlert,
+    iconClass: "text-amber-600 dark:text-amber-400",
+    cardClass: "border-amber-500/40 bg-amber-500/5",
+  },
+  info: {
+    Icon: Info,
+    iconClass: "text-sky-600 dark:text-sky-400",
+    cardClass: "border-border bg-muted/30",
+  },
+};
+
+const CATEGORY_ORDER: {
+  key: HandlungsbedarfCategory;
+  label: string;
+  hint: string;
+}[] = [
+  {
+    key: "krankheit",
+    label: "Krankheit & Vertretung",
+    hint: "Erkrankte Schulbegleiter, abwesende Kinder und betroffene Vertretungen.",
+  },
+  {
+    key: "weitere",
+    label: "Weitere Handlungsbedarfe",
+    hint: "Auffälligkeiten in Einsätzen und Stundenplänen.",
+  },
+  {
+    key: "stammdaten",
+    label: "Stammdaten-Hinweise",
+    hint: "Fehlende Unterlagen — unabhängig von der gewählten Woche.",
+  },
+];
+
+function parseIsoLocal(iso: string): Date {
+  return new Date(`${iso}T00:00:00`);
+}
+
+export function HandlungsbedarfDashboard({
+  initialResult,
+  initialWeekStartIso,
+  schoolAssistantOptions,
+}: Props) {
+  const [weekStart, setWeekStart] = useState<Date>(() =>
+    parseIsoLocal(initialWeekStartIso),
+  );
+  const [result, setResult] = useState<HandlungsbedarfResult>(initialResult);
+  const [loading, setLoading] = useState(false);
+
+  function load(next: Date) {
+    setWeekStart(next);
+    setLoading(true);
+    getHandlungsbedarfAction(formatIsoDateLocal(next))
+      .then(setResult)
+      .catch(() => toast.error("Handlungsbedarf konnte nicht geladen werden."))
+      .finally(() => setLoading(false));
+  }
+
+  function refresh() {
+    setLoading(true);
+    getHandlungsbedarfAction(formatIsoDateLocal(weekStart))
+      .then(setResult)
+      .catch(() => toast.error("Aktualisieren fehlgeschlagen."))
+      .finally(() => setLoading(false));
+  }
+
+  const { counts, cases } = result;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border bg-card px-5 py-5 shadow-none sm:px-6">
+        <div className="flex flex-col gap-4">
+          <div>
+            <h1 className="text-xl font-semibold sm:text-2xl">
+              Handlungsbedarf
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Problematische Fälle dieser Woche auf einen Blick.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => load(addDays(weekStart, -7))}
+                aria-label="Vorherige Woche"
+              >
+                <ChevronLeft />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => load(startOfWeekMonday(new Date()))}
+              >
+                Heute
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => load(addDays(weekStart, 7))}
+                aria-label="Nächste Woche"
+              >
+                <ChevronRight />
+              </Button>
+              <span className="ml-1 text-sm font-medium">
+                {germanWeekRangeLabel(weekStart)}
+              </span>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {counts.critical > 0 ? (
+                <Badge variant="destructive">{counts.critical} kritisch</Badge>
+              ) : null}
+              {counts.warning > 0 ? (
+                <Badge
+                  variant="outline"
+                  className="border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                >
+                  {counts.warning} Warnungen
+                </Badge>
+              ) : null}
+              {counts.info > 0 ? (
+                <Badge variant="secondary">{counts.info} Hinweise</Badge>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "space-y-6 transition-opacity",
+          loading && "pointer-events-none opacity-60",
+        )}
+      >
+        {cases.length === 0 ? (
+          <Card>
+            <CardContent className="flex flex-col items-center gap-2 py-12 text-center">
+              <CircleCheck className="size-8 text-emerald-600 dark:text-emerald-400" />
+              <p className="font-medium">
+                Kein Handlungsbedarf in dieser Woche.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Alle Fälle sind versorgt.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          CATEGORY_ORDER.map((category) => {
+            const sectionCases = cases.filter(
+              (c) => c.category === category.key,
+            );
+            if (sectionCases.length === 0) return null;
+            return (
+              <Card key={category.key}>
+                <CardHeader>
+                  <CardTitle className="text-base">
+                    {category.label}{" "}
+                    <span className="text-muted-foreground">
+                      ({sectionCases.length})
+                    </span>
+                  </CardTitle>
+                  <CardDescription>{category.hint}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  {sectionCases.map((c) => (
+                    <CaseRow
+                      key={c.id}
+                      caseItem={c}
+                      schoolAssistantOptions={schoolAssistantOptions}
+                      onResolved={refresh}
+                    />
+                  ))}
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CaseRow({
+  caseItem,
+  schoolAssistantOptions,
+  onResolved,
+}: {
+  caseItem: HandlungsbedarfCase;
+  schoolAssistantOptions: SchoolAssistantOption[];
+  onResolved: () => void;
+}) {
+  const meta = SEVERITY_META[caseItem.severity];
+  const Icon = meta.Icon;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between",
+        meta.cardClass,
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <Icon className={cn("mt-0.5 size-5 shrink-0", meta.iconClass)} />
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium">{caseItem.title}</span>
+            {caseItem.date ? (
+              <Badge
+                variant="outline"
+                className="font-normal"
+              >
+                {formatShortDateWithWeekday(caseItem.date)}
+              </Badge>
+            ) : null}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {caseItem.description}
+          </p>
+        </div>
+      </div>
+
+      {caseItem.assign ? (
+        <div className="shrink-0 sm:pl-3">
+          <AssignVertretungDialog
+            target={caseItem.assign}
+            schoolAssistantOptions={schoolAssistantOptions}
+            onResolved={onResolved}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -39,8 +39,10 @@ import {
   listChildren,
   listSchedulesForChild,
   listSchedulesForChildren,
+  listSickEventsInRange,
   listVertretungenForUserAsSubstitute,
   listWorkEventsForChild,
+  listWorkEventsInRange,
   syncVertretungBlocksForChildWeekday,
   listWorkEventsForChildInRange,
   updateAssignment,
@@ -52,6 +54,12 @@ import {
   deleteWorkEventAsAdmin,
   restoreWorkEventAsAdmin,
 } from "./services";
+import { formatIsoDateUtc } from "@/lib/utils";
+import { serializeChild } from "./serialize";
+import {
+  detectHandlungsbedarf,
+  type HandlungsbedarfResult,
+} from "./handlungsbedarf";
 
 function childFieldsFromCreate(input: CreateChildInput) {
   return {
@@ -319,5 +327,42 @@ export const ChildrenFacade = {
 
   async listWorkEventsForChildInRange(childId: string, from: Date, to: Date) {
     return listWorkEventsForChildInRange(childId, from, to);
+  },
+
+  /**
+   * COD-50 — Handlungsbedarf dashboard. Loads every child (with assignments,
+   * Stundenplan, absences and Vertretungen) plus the week's SICK and WORK
+   * events, then derives the list of problematic cases for the given week.
+   * `weekStartIso` is the Monday (YYYY-MM-DD); the range is [Mon, next Mon).
+   */
+  async getHandlungsbedarf(
+    weekStartIso: string,
+  ): Promise<HandlungsbedarfResult> {
+    const from = new Date(`${weekStartIso}T00:00:00.000Z`);
+    const to = new Date(from.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+    const [children, sickEvents, workEvents] = await Promise.all([
+      listChildren(),
+      listSickEventsInRange(from, to),
+      listWorkEventsInRange(from, to),
+    ]);
+
+    return detectHandlungsbedarf({
+      weekStartIso,
+      children: children.map(serializeChild),
+      sickEvents: sickEvents.map((e) => ({
+        userId: e.userId,
+        userName: e.user.name,
+        date: formatIsoDateUtc(e.date),
+      })),
+      workEvents: workEvents.map((e) => ({
+        // childId is guaranteed non-null by listWorkEventsInRange's filter.
+        childId: e.childId as string,
+        userName: e.user.name,
+        date: formatIsoDateUtc(e.date),
+        startTime: e.startTime,
+        endTime: e.endTime,
+      })),
+    });
   },
 };

--- a/src/features/children/handlungsbedarf.ts
+++ b/src/features/children/handlungsbedarf.ts
@@ -1,0 +1,487 @@
+// COD-50 — "Übersicht problematischer Fälle".
+//
+// Pure detection logic for the admin Handlungsbedarf dashboard. Given the
+// already-loaded children (with their assignments, schedules, absences and
+// Vertretungen) plus the SICK and WORK events of a single week, it derives a
+// flat, sorted list of cases that need attention.
+//
+// This module is intentionally side-effect free and infrastructure-agnostic so
+// it stays trivially testable: the ChildrenFacade fetches the data, this
+// function turns it into cases, the Action ships the result to the UI.
+
+import { addDays, parseIsoDate, timeToMinutes } from "@/lib/dates";
+import { formatIsoDateUtc } from "@/lib/utils";
+import type { SerializedChild } from "./serialize";
+
+/** Booked minutes must exceed the Stundenplan by more than this to be flagged. */
+export const HOURS_OVER_SCHEDULE_THRESHOLD_MIN = 60;
+
+export type HandlungsbedarfSeverity = "critical" | "warning" | "info";
+
+export type HandlungsbedarfCategory = "krankheit" | "weitere" | "stammdaten";
+
+export type HandlungsbedarfKind =
+  | "sa-sick-uncovered"
+  | "sa-sick-covered"
+  | "sa-sick-no-children"
+  | "child-absent"
+  | "child-absent-but-work"
+  | "substitute-sick"
+  | "schedule-unassigned"
+  | "hours-over-schedule"
+  | "missing-schweigepflicht"
+  | "missing-bescheid";
+
+/**
+ * Everything the inline "Vertretung zuweisen" dialog needs. `currentSubstituteUserId`
+ * is null when no Vertretung exists yet (→ create), or the existing substitute
+ * when one is in place but needs replacing (→ update).
+ */
+export type VertretungAssignTarget = {
+  childId: string;
+  childName: string;
+  date: string; // YYYY-MM-DD
+  currentSubstituteUserId: string | null;
+  scheduleLabel: string; // e.g. "08:00–14:00" or "Ganztägig"
+};
+
+export type HandlungsbedarfCase = {
+  id: string;
+  category: HandlungsbedarfCategory;
+  severity: HandlungsbedarfSeverity;
+  kind: HandlungsbedarfKind;
+  title: string;
+  description: string;
+  date: string | null; // YYYY-MM-DD, or null for non-date-bound (Stammdaten) cases
+  weekday: number | null; // 0..6 (Mon..Sun), or null
+  childId: string | null;
+  childName: string | null;
+  schoolAssistantName: string | null;
+  assign: VertretungAssignTarget | null; // present → render inline assign action
+};
+
+export type HandlungsbedarfCounts = {
+  critical: number;
+  warning: number;
+  info: number;
+};
+
+export type HandlungsbedarfResult = {
+  weekStart: string; // ISO Monday
+  weekEnd: string; // ISO Sunday
+  cases: HandlungsbedarfCase[];
+  counts: HandlungsbedarfCounts;
+};
+
+export type SickEventLite = {
+  userId: string;
+  userName: string;
+  date: string; // YYYY-MM-DD
+};
+
+export type WorkEventLite = {
+  childId: string;
+  userName: string;
+  date: string; // YYYY-MM-DD
+  startTime: string | null;
+  endTime: string | null;
+};
+
+export type DetectHandlungsbedarfInput = {
+  weekStartIso: string; // ISO Monday (YYYY-MM-DD)
+  children: SerializedChild[];
+  sickEvents: SickEventLite[];
+  workEvents: WorkEventLite[];
+};
+
+const SEVERITY_RANK: Record<HandlungsbedarfSeverity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+function scheduleLabelForWeekday(
+  child: SerializedChild,
+  weekday: number,
+): string {
+  const blocks = child.schedules
+    .filter((s) => s.weekday === weekday)
+    .sort((a, b) => a.startTime.localeCompare(b.startTime));
+  if (blocks.length === 0) return "Ganztägig";
+  return blocks.map((b) => `${b.startTime}–${b.endTime}`).join(", ");
+}
+
+function minutesForBlocks(
+  blocks: { startTime: string; endTime: string }[],
+): number {
+  return blocks.reduce(
+    (sum, b) =>
+      sum + Math.max(0, timeToMinutes(b.endTime) - timeToMinutes(b.startTime)),
+    0,
+  );
+}
+
+function formatMinutes(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  if (h === 0) return `${m} min`;
+  return m === 0 ? `${h} h` : `${h} h ${m} min`;
+}
+
+export function detectHandlungsbedarf(
+  input: DetectHandlungsbedarfInput,
+): HandlungsbedarfResult {
+  const { weekStartIso, children, sickEvents, workEvents } = input;
+
+  const monday = parseIsoDate(weekStartIso);
+  // 7 ISO dates Mon..Sun; the array index IS the Mon=0 weekday index.
+  const weekDates = Array.from({ length: 7 }, (_, i) =>
+    formatIsoDateUtc(addDays(monday, i)),
+  );
+  const weekDateSet = new Set(weekDates);
+  const weekdayOf = new Map<string, number>();
+  weekDates.forEach((iso, i) => weekdayOf.set(iso, i));
+
+  // --- index SICK events: date -> Set<userId> (+ name lookup) ---
+  const sickByDate = new Map<string, Set<string>>();
+  const sickUserName = new Map<string, string>();
+  for (const ev of sickEvents) {
+    if (!weekDateSet.has(ev.date)) continue;
+    if (!sickByDate.has(ev.date)) sickByDate.set(ev.date, new Set());
+    sickByDate.get(ev.date)!.add(ev.userId);
+    sickUserName.set(ev.userId, ev.userName);
+  }
+  const isSick = (userId: string, date: string) =>
+    sickByDate.get(date)?.has(userId) ?? false;
+
+  // --- index WORK events: `${childId}|${date}` -> events ---
+  const workByChildDate = new Map<string, WorkEventLite[]>();
+  for (const ev of workEvents) {
+    if (!weekDateSet.has(ev.date)) continue;
+    const key = `${ev.childId}|${ev.date}`;
+    if (!workByChildDate.has(key)) workByChildDate.set(key, []);
+    workByChildDate.get(key)!.push(ev);
+  }
+
+  const cases: HandlungsbedarfCase[] = [];
+
+  for (const child of children) {
+    const childName = `${child.firstName} ${child.lastName}`;
+
+    // Absences that fall inside the visible week.
+    const absentDates = new Set(
+      child.absences.map((a) => a.date).filter((d) => weekDateSet.has(d)),
+    );
+
+    // Vertretungen within the week, one (the first) substitute per date.
+    const vertretungByDate = new Map<
+      string,
+      { substituteUserId: string; substituteUserName: string }
+    >();
+    for (const v of child.vertretungen) {
+      if (!weekDateSet.has(v.date)) continue;
+      if (!vertretungByDate.has(v.date)) {
+        vertretungByDate.set(v.date, {
+          substituteUserId: v.substituteUserId,
+          substituteUserName: v.substituteUserName,
+        });
+      }
+    }
+
+    // Assigned Schulbegleiter per weekday (deduped by user).
+    const assignedUsersByWeekday = new Map<
+      number,
+      { userId: string; userName: string }[]
+    >();
+    for (const a of child.assignments) {
+      if (!assignedUsersByWeekday.has(a.weekday)) {
+        assignedUsersByWeekday.set(a.weekday, []);
+      }
+      const arr = assignedUsersByWeekday.get(a.weekday)!;
+      if (!arr.some((u) => u.userId === a.userId)) {
+        arr.push({ userId: a.userId, userName: a.userName });
+      }
+    }
+
+    const scheduleWeekdays = new Set(child.schedules.map((s) => s.weekday));
+
+    // === Kind krank/abwesend (and the "but WORK was booked" variant) ===
+    for (const date of absentDates) {
+      const weekday = weekdayOf.get(date)!;
+      const work = workByChildDate.get(`${child.id}|${date}`) ?? [];
+      if (work.length > 0) {
+        const names = Array.from(new Set(work.map((w) => w.userName))).join(
+          ", ",
+        );
+        cases.push({
+          id: `child-absent-but-work:${child.id}:${date}`,
+          category: "weitere",
+          severity: "warning",
+          kind: "child-absent-but-work",
+          title: "Kind krank, aber Einsatz gebucht",
+          description: `${childName} ist als abwesend markiert, ${names} hat an diesem Tag dennoch einen Einsatz gebucht.`,
+          date,
+          weekday,
+          childId: child.id,
+          childName,
+          schoolAssistantName: names,
+          assign: null,
+        });
+      } else {
+        cases.push({
+          id: `child-absent:${child.id}:${date}`,
+          category: "krankheit",
+          severity: "info",
+          kind: "child-absent",
+          title: "Kind abwesend / krank",
+          description: `${childName} ist an diesem Tag als abwesend markiert.`,
+          date,
+          weekday,
+          childId: child.id,
+          childName,
+          schoolAssistantName: null,
+          assign: null,
+        });
+      }
+    }
+
+    // === Per-weekday rules within the visible week ===
+    for (let weekday = 0; weekday < 7; weekday++) {
+      const date = weekDates[weekday];
+      const childAbsent = absentDates.has(date);
+      const vertretung = vertretungByDate.get(date) ?? null;
+      const assignedUsers = assignedUsersByWeekday.get(weekday) ?? [];
+
+      // --- Schulbegleiter krank → covered / uncovered ---
+      for (const u of assignedUsers) {
+        if (!isSick(u.userId, date)) continue;
+        if (childAbsent) continue; // child is away too → no substitute needed
+        if (vertretung) {
+          cases.push({
+            id: `sa-sick-covered:${u.userId}:${child.id}:${date}`,
+            category: "krankheit",
+            severity: "info",
+            kind: "sa-sick-covered",
+            title: "Schulbegleiter krank — Vertretung vorhanden",
+            description: `${u.userName} ist krank. ${childName} wird von ${vertretung.substituteUserName} vertreten.`,
+            date,
+            weekday,
+            childId: child.id,
+            childName,
+            schoolAssistantName: u.userName,
+            assign: null,
+          });
+        } else {
+          cases.push({
+            id: `sa-sick-uncovered:${u.userId}:${child.id}:${date}`,
+            category: "krankheit",
+            severity: "critical",
+            kind: "sa-sick-uncovered",
+            title: "Schulbegleiter krank — keine Vertretung",
+            description: `${u.userName} ist krank. ${childName} hat noch keine Vertretung.`,
+            date,
+            weekday,
+            childId: child.id,
+            childName,
+            schoolAssistantName: u.userName,
+            assign: {
+              childId: child.id,
+              childName,
+              date,
+              currentSubstituteUserId: null,
+              scheduleLabel: scheduleLabelForWeekday(child, weekday),
+            },
+          });
+        }
+      }
+
+      // --- Vertretung, deren Vertreter selbst krank ist ---
+      if (
+        vertretung &&
+        !childAbsent &&
+        isSick(vertretung.substituteUserId, date)
+      ) {
+        cases.push({
+          id: `substitute-sick:${child.id}:${date}`,
+          category: "krankheit",
+          severity: "critical",
+          kind: "substitute-sick",
+          title: "Vertreter krank",
+          description: `Die Vertretung für ${childName} (${vertretung.substituteUserName}) ist an diesem Tag selbst krank.`,
+          date,
+          weekday,
+          childId: child.id,
+          childName,
+          schoolAssistantName: vertretung.substituteUserName,
+          assign: {
+            childId: child.id,
+            childName,
+            date,
+            currentSubstituteUserId: vertretung.substituteUserId,
+            scheduleLabel: scheduleLabelForWeekday(child, weekday),
+          },
+        });
+      }
+
+      // --- Stundenplan-Block ohne zugewiesenen Schulbegleiter ---
+      if (
+        scheduleWeekdays.has(weekday) &&
+        assignedUsers.length === 0 &&
+        !childAbsent &&
+        !vertretung
+      ) {
+        cases.push({
+          id: `schedule-unassigned:${child.id}:${date}`,
+          category: "weitere",
+          severity: "warning",
+          kind: "schedule-unassigned",
+          title: "Stundenplan-Block ohne Schulbegleiter",
+          description: `${childName} hat laut Stundenplan einen Block (${scheduleLabelForWeekday(
+            child,
+            weekday,
+          )}), aber keinen zugewiesenen Schulbegleiter.`,
+          date,
+          weekday,
+          childId: child.id,
+          childName,
+          schoolAssistantName: null,
+          assign: {
+            childId: child.id,
+            childName,
+            date,
+            currentSubstituteUserId: null,
+            scheduleLabel: scheduleLabelForWeekday(child, weekday),
+          },
+        });
+      }
+
+      // --- Gebuchte Stunden deutlich über Stundenplan ---
+      if (scheduleWeekdays.has(weekday)) {
+        const scheduledMin = minutesForBlocks(
+          child.schedules.filter((s) => s.weekday === weekday),
+        );
+        const work = workByChildDate.get(`${child.id}|${date}`) ?? [];
+        const bookedMin = work.reduce((sum, w) => {
+          if (!w.startTime || !w.endTime) return sum;
+          return (
+            sum +
+            Math.max(0, timeToMinutes(w.endTime) - timeToMinutes(w.startTime))
+          );
+        }, 0);
+        if (
+          scheduledMin > 0 &&
+          bookedMin > scheduledMin + HOURS_OVER_SCHEDULE_THRESHOLD_MIN
+        ) {
+          cases.push({
+            id: `hours-over-schedule:${child.id}:${date}`,
+            category: "weitere",
+            severity: "warning",
+            kind: "hours-over-schedule",
+            title: "Gebuchte Stunden über Stundenplan",
+            description: `Für ${childName} wurden ${formatMinutes(
+              bookedMin,
+            )} gebucht, der Stundenplan sieht ${formatMinutes(
+              scheduledMin,
+            )} vor.`,
+            date,
+            weekday,
+            childId: child.id,
+            childName,
+            schoolAssistantName: null,
+            assign: null,
+          });
+        }
+      }
+    }
+
+    // === Stammdaten-Hinweise (not tied to the visible week) ===
+    if (!child.schweigepflichtsentbindung) {
+      cases.push({
+        id: `missing-schweigepflicht:${child.id}`,
+        category: "stammdaten",
+        severity: "warning",
+        kind: "missing-schweigepflicht",
+        title: "Fehlende Schweigepflichtsentbindung",
+        description: `Für ${childName} liegt keine Schweigepflichtsentbindung vor.`,
+        date: null,
+        weekday: null,
+        childId: child.id,
+        childName,
+        schoolAssistantName: null,
+        assign: null,
+      });
+    }
+    if (!child.bescheid || child.bescheid.trim() === "") {
+      cases.push({
+        id: `missing-bescheid:${child.id}`,
+        category: "stammdaten",
+        severity: "info",
+        kind: "missing-bescheid",
+        title: "Kein Bescheid hinterlegt",
+        description: `Für ${childName} ist kein Bescheid hinterlegt.`,
+        date: null,
+        weekday: null,
+        childId: child.id,
+        childName,
+        schoolAssistantName: null,
+        assign: null,
+      });
+    }
+  }
+
+  // Surface sick Schulbegleiter who have NO assigned child on the sick day, so
+  // the illness still shows up in the list. (Days where an assignment exists are
+  // already represented by covered/uncovered cases above.)
+  const sickDaysWithAssignment = new Set<string>();
+  for (const child of children) {
+    for (const a of child.assignments) {
+      const date = weekDates[a.weekday];
+      if (date && isSick(a.userId, date)) {
+        sickDaysWithAssignment.add(`${a.userId}|${date}`);
+      }
+    }
+  }
+  for (const [date, userSet] of sickByDate) {
+    const weekday = weekdayOf.get(date)!;
+    for (const userId of userSet) {
+      if (sickDaysWithAssignment.has(`${userId}|${date}`)) continue;
+      cases.push({
+        id: `sa-sick-no-children:${userId}:${date}`,
+        category: "krankheit",
+        severity: "info",
+        kind: "sa-sick-no-children",
+        title: "Schulbegleiter krank",
+        description: `${
+          sickUserName.get(userId) ?? "Schulbegleiter"
+        } ist krank — keine zugewiesenen Kinder an diesem Tag.`,
+        date,
+        weekday,
+        childId: null,
+        childName: null,
+        schoolAssistantName: sickUserName.get(userId) ?? null,
+        assign: null,
+      });
+    }
+  }
+
+  // Sort by severity, then by date (non-date-bound cases last), then title.
+  cases.sort((a, b) => {
+    if (SEVERITY_RANK[a.severity] !== SEVERITY_RANK[b.severity]) {
+      return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    }
+    const da = a.date ?? "9999-99-99";
+    const db = b.date ?? "9999-99-99";
+    if (da !== db) return da.localeCompare(db);
+    return a.title.localeCompare(b.title);
+  });
+
+  const counts: HandlungsbedarfCounts = { critical: 0, warning: 0, info: 0 };
+  for (const c of cases) counts[c.severity]++;
+
+  return {
+    weekStart: weekDates[0],
+    weekEnd: weekDates[6],
+    cases,
+    counts,
+  };
+}

--- a/src/features/children/index.ts
+++ b/src/features/children/index.ts
@@ -16,3 +16,11 @@ export {
   type SerializedSchedule,
 } from "./serialize";
 export { ChildrenTable } from "./components/children-table";
+export { HandlungsbedarfDashboard } from "./components/handlungsbedarf/handlungsbedarf-dashboard";
+export type {
+  HandlungsbedarfCase,
+  HandlungsbedarfCategory,
+  HandlungsbedarfCounts,
+  HandlungsbedarfResult,
+  HandlungsbedarfSeverity,
+} from "./handlungsbedarf";

--- a/src/features/children/services/events.ts
+++ b/src/features/children/services/events.ts
@@ -104,3 +104,52 @@ export async function listWorkEventsForChildInRange(
     orderBy: { date: "asc" },
   });
 }
+
+export type SickEventWithUser = Prisma.EventGetPayload<{
+  include: { user: true };
+}>;
+
+/**
+ * All SICK events across every Schulbegleiter in a half-open date range
+ * `[from, to)`. Used by the Handlungsbedarf dashboard to find sick assistants.
+ * Soft-deleted entries are excluded.
+ */
+export async function listSickEventsInRange(
+  from: Date,
+  to: Date,
+): Promise<SickEventWithUser[]> {
+  return prisma.event.findMany({
+    where: {
+      type: EventType.SICK,
+      deleted: false,
+      date: { gte: from, lt: to },
+    },
+    include: { user: true },
+    orderBy: { date: "asc" },
+  });
+}
+
+export type WorkEventWithChildAndUser = Prisma.EventGetPayload<{
+  include: { user: true; child: true };
+}>;
+
+/**
+ * All WORK events across every child in a half-open date range `[from, to)`.
+ * Used by the Handlungsbedarf dashboard to cross-check booked hours against
+ * absences and the Stundenplan. Soft-deleted entries are excluded.
+ */
+export async function listWorkEventsInRange(
+  from: Date,
+  to: Date,
+): Promise<WorkEventWithChildAndUser[]> {
+  return prisma.event.findMany({
+    where: {
+      type: EventType.WORK,
+      deleted: false,
+      childId: { not: null },
+      date: { gte: from, lt: to },
+    },
+    include: { user: true, child: true },
+    orderBy: { date: "asc" },
+  });
+}


### PR DESCRIPTION
## COD-50 — (Admin) Übersicht problematischer Fälle

Adds a new **Handlungsbedarf** dashboard at `/admin/handlungsbedarf` (new sidebar entry) that flags cases needing attention for a selectable week and lets admins resolve the core pain — assigning a Vertretung — **inline**.

Resolves [COD-50](https://linear.app/coding-for-change/issue/COD-50).

### What it does
- **Week-based view** with a prev / „Heute" / next switcher and the week's date range in the header, mirroring the Kinder Kalender. Defaults to the current week; switching weeks re-fetches via a server action.
- **Cases grouped into three sections**, sorted by severity:
  - **Krankheit & Vertretung** (top, per the issue): erkrankte Schulbegleiter → betroffene Kinder mit/ohne Vertretung, erkrankte Kinder, und Vertretungen deren Vertreter selbst krank ist.
  - **Weitere Handlungsbedarfe**: Kind krank aber Einsatz gebucht · Stundenplan-Block ohne zugewiesenen Schulbegleiter · gebuchte Stunden deutlich über Stundenplan (> 60 min).
  - **Stammdaten-Hinweise** (wochenunabhängig): fehlende Schweigepflichtsentbindung · kein Bescheid hinterlegt.
- **Inline „Vertretung zuweisen" / „Vertretung ändern"** on the relevant cases, reusing the existing Vertretung flow (`createVertretungAction` / `updateVertretungAction`); times mirror the Stundenplan. The list refreshes after saving.

### Architecture
- Pure, testable detection in `src/features/children/handlungsbedarf.ts` (`detectHandlungsbedarf`).
- `ChildrenFacade.getHandlungsbedarf(weekStartIso)` + `getHandlungsbedarfAction` (admin-guarded). New cross-user services `listSickEventsInRange` / `listWorkEventsInRange`.
- Single-feature (all data lives in / is reachable from the `children` domain) → intentionally **no** Use Case, per `AGENTS.md`. Documented in `docs/ARCHITECTURE.md` and `docs/architecture/dependency-graph.md`.

### Known limitation
The issue mentions „Abgelaufener Bescheid". `Child.bescheid` is free text with **no expiry date** in the schema, so this PR flags **missing** Bescheid (empty) instead. True expiry tracking needs a new date field — left as a follow-up.

---

## How to test

**Prerequisites**
1. `npm run db:seed` — spins up the DB (Docker) and loads test data (admins, Schulbegleiter, Kinder, Stundenpläne, assignments).
2. `npm run dev` (or `npm run dev:local` if auth requires the LAN IP) and open http://localhost:3000.
3. Log in as **admin@lebenshilfe.de / password123**, then click **Handlungsbedarf** in the sidebar.

**Week navigation**
- Use ◀ / ▶ to move between weeks and **Heute** to jump back to the current week. Confirm the date range label and the case list update per week, and the count badges (kritisch / Warnungen / Hinweise) reflect the list.

**Trigger each case type** (seed data already produces several; to create specific ones):

| Case | How to produce it |
| --- | --- |
| **Schulbegleiter krank — keine Vertretung** (critical) | As a Schulbegleiter (e.g. anna.schmidt@lebenshilfe.de / password123) book a **SICK** entry on a day they're assigned to a child. The child appears with a red **Vertretung zuweisen** button. |
| **Schulbegleiter krank — Vertretung vorhanden** (info) | After assigning a Vertretung for the above, it flips to the info „Vertretung vorhanden" variant. |
| **Vertreter krank** (critical) | Assign a substitute to a child for a date, then book that substitute **SICK** on the same date → **Vertretung ändern**. |
| **Kind krank, aber Einsatz gebucht** (warning) | In `/admin/children` mark a child absent on a date, then have an SB book **WORK** for that child the same day (or admin-create the WORK entry). |
| **Kind abwesend / krank** (info) | Mark a child absent on a day with no WORK booked. |
| **Stundenplan-Block ohne Schulbegleiter** (warning) | A child with a Stundenplan block on a weekday but no assignment for that weekday → **Vertretung zuweisen** for that date. |
| **Gebuchte Stunden über Stundenplan** (warning) | Book WORK exceeding the day's Stundenplan total by more than 60 min. |
| **Fehlende Schweigepflichtsentbindung / kein Bescheid** | In `/admin/children` leave Schweigepflichtsentbindung off / Bescheid empty for a child. |

**Inline action**
- Click **Vertretung zuweisen** on a critical case → pick a Schulbegleiter → **Speichern**. Confirm the toast, that the list refreshes, and the case disappears / flips to „Vertretung vorhanden". Verify the Vertretung also shows on that child in `/admin/children` (Kalender).
- For **Vertreter krank**, use **Vertretung ändern** to swap to a different (healthy) substitute.

**Empty state**
- Switch to a week with no issues → a green „Kein Handlungsbedarf in dieser Woche." card.

### Automated checks run locally
`npx tsc --noEmit` ✓ · `npx eslint src` ✓ (boundaries pass) · `npx prettier --check` ✓ · `npx next build` ✓
