### PR TITLE
COD-51: Vertretungs-Eintrag — free-text child matching + admin queue

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,3 +75,39 @@ single-feature operation is **not** a Use Case.
   `createVertretungAction` / `updateVertretungAction`.
 
 See `docs/architecture/dependency-graph.md` for the diagram.
+
+### Vertretung-Requests: free-text child matching (COD-51)
+A Schulbegleiter can report a Vertretung for a child they are **not** assigned
+to. The child is entered as **free text** (`childNameText`) — the roster is
+never shown to the companion (Datenschutz). The server fuzzy-matches the text
+against the roster and stores a *suggestion only*; nothing is auto-confirmed.
+An admin resolves each report in the "Zuzuordnen" section of the Handlungsbedarf
+tab (COD-50): confirming materialises the billable `WORK` `Event` (carrying the
+companion's signature) **and** a `ChildVertretung`, so an unresolved report
+never reaches billing/export.
+
+It lives in its own bounded context, `features/vertretung-requests/`, because it
+owns a new table (`VertretungRequest`) and is initiated from the timesheet UI,
+independent of the children domain.
+
+- **Matching** is split cleanly: the pure string math is `lib/fuzzy.ts`
+  (`nameSimilarity`, robust to umlauts/diacritics/word-order); the roster
+  ranking is a children service (`rankChildrenByName`); the threshold decision
+  is `ChildrenFacade.matchChildByFreeText` (suggests only when confident AND
+  unambiguous). The roster never leaves the server.
+- **Facade**: `VertretungRequestsFacade` owns the `VertretungRequest` table only
+  (create / listPending / get / markConfirmed / markRejected) and uploads the
+  companion's signature. It stays free of auth/HTTP.
+- **Use Cases** (cross-feature, two facades each):
+  - `submit-vertretung-request` — `ChildrenFacade.matchChildByFreeText` →
+    `VertretungRequestsFacade.createRequest`.
+  - `resolve-vertretung-request` — on admin confirm, `ChildrenFacade`
+    creates the signed `Event` + the `ChildVertretung`, then
+    `VertretungRequestsFacade.markConfirmed`.
+- **Actions**: `submitVertretungRequestAction` (`requireAuth` → submit use case),
+  `confirmVertretungRequestAction` (`requireAdmin` → resolve use case),
+  `rejectVertretungRequestAction` (`requireAdmin` → Facade directly,
+  single-feature), `listPendingVertretungRequestsAction` (`requireAdmin`).
+- **UI**: a third "Vertretung" mode in the timesheet new-entry sheet (free-text
+  child, manual time, signature) and the `VertretungQueue` component mounted in
+  the Handlungsbedarf page.

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -18,6 +18,8 @@ graph TD
         UC_removeAdmin[remove-admin-user]
         UC_resendAdmin[resend-admin-invitation]
         UC_resendSA[resend-school-assistant-invitation]
+        UC_submitVR[submit-vertretung-request]
+        UC_resolveVR[resolve-vertretung-request]
     end
 
     subgraph "Feature Facades"
@@ -26,6 +28,7 @@ graph TD
         F_sa[SchoolAssistantsFacade]
         F_invitation[InvitationFacade]
         F_user[UserFacade]
+        F_vr[VertretungRequestsFacade]
     end
 
     UC_cancelInvite --> F_invitation
@@ -44,6 +47,31 @@ graph TD
     UC_resendAdmin --> F_invitation
     UC_resendSA --> F_invitation
     UC_resendSA --> F_sa
+    UC_submitVR --> F_children
+    UC_submitVR --> F_vr
+    UC_resolveVR --> F_children
+    UC_resolveVR --> F_vr
+```
+
+## Vertretung-Request flow (COD-51)
+
+A Schulbegleiter-reported substitution with a **free-text** child name. Two
+cross-feature Use Cases coordinate `ChildrenFacade` and
+`VertretungRequestsFacade`; the roster is matched server-side and never shown
+to the companion. Nothing reaches billing until an admin confirms (which then
+materialises the `Event` + `ChildVertretung`).
+
+```mermaid
+graph LR
+    SB["Schulbegleiter: new-entry sheet"] --> A_submit[submitVertretungRequestAction]
+    A_submit --> UC_submitVR[submit-vertretung-request]
+    UC_submitVR --> F_children[ChildrenFacade.matchChildByFreeText]
+    UC_submitVR --> F_vr[VertretungRequestsFacade.createRequest]
+
+    Admin["Admin: Handlungsbedarf · Zuzuordnen"] --> A_confirm[confirmVertretungRequestAction]
+    A_confirm --> UC_resolveVR[resolve-vertretung-request]
+    UC_resolveVR --> F_children2[ChildrenFacade: signed Event + ChildVertretung]
+    UC_resolveVR --> F_vr2[VertretungRequestsFacade.markConfirmed]
 ```
 
 ## Single-feature flows (no Use Case)

--- a/prisma/migrations/20260603160000_add_vertretung_request/migration.sql
+++ b/prisma/migrations/20260603160000_add_vertretung_request/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE `vertretung_request` (
+    `id` VARCHAR(191) NOT NULL,
+    `reportedByUserId` VARCHAR(191) NOT NULL,
+    `childNameText` VARCHAR(191) NOT NULL,
+    `date` DATE NOT NULL,
+    `startTime` VARCHAR(191) NOT NULL,
+    `endTime` VARCHAR(191) NOT NULL,
+    `note` TEXT NULL,
+    `signatureKey` VARCHAR(191) NOT NULL,
+    `status` ENUM('PENDING', 'CONFIRMED', 'REJECTED') NOT NULL DEFAULT 'PENDING',
+    `suggestedChildId` VARCHAR(191) NULL,
+    `matchScore` DOUBLE NULL,
+    `resolvedChildId` VARCHAR(191) NULL,
+    `resolvedByUserId` VARCHAR(191) NULL,
+    `resolvedEventId` VARCHAR(191) NULL,
+    `resolvedAt` DATETIME(3) NULL,
+    `rejectionReason` TEXT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    INDEX `vertretung_request_status_idx`(`status`),
+    INDEX `vertretung_request_reportedByUserId_idx`(`reportedByUserId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `vertretung_request` ADD CONSTRAINT `vertretung_request_reportedByUserId_fkey` FOREIGN KEY (`reportedByUserId`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `vertretung_request` ADD CONSTRAINT `vertretung_request_suggestedChildId_fkey` FOREIGN KEY (`suggestedChildId`) REFERENCES `child`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,12 @@ enum EventType {
   SICK
 }
 
+enum VertretungRequestStatus {
+  PENDING
+  CONFIRMED
+  REJECTED
+}
+
 enum SchulbegleiterStatus {
   INVITATION_PENDING
   ACCEPTED
@@ -43,6 +49,7 @@ model User {
   monthlyReports MonthlyReport[]
   profile       SchoolAssistantProfile?
   vertretungenAsSubstitute  ChildVertretung[] @relation("SubstituteVertretung")
+  vertretungRequests        VertretungRequest[] @relation("VertretungRequestReporter")
 
   @@unique([email])
   @@map("user")
@@ -133,6 +140,7 @@ model Child {
   events                     Event[]
   absences                   ChildAbsence[]
   vertretungen               ChildVertretung[]
+  suggestedVertretungRequests VertretungRequest[] @relation("VertretungRequestSuggestedChild")
 
   @@index([kostentraegerId])
   @@map("child")
@@ -171,6 +179,41 @@ model ChildVertretung {
   @@index([childId, date])
   @@index([substituteUserId, date])
   @@map("child_vertretung")
+}
+
+/// A Schulbegleiter-reported substitution ("Vertretung") for a child they are
+/// NOT assigned to. The child is captured as free text (`childNameText`) for
+/// Datenschutz reasons — the roster is never shown to the companion. The server
+/// fuzzy-matches the text against the child roster and stores a *suggestion*
+/// only (`suggestedChildId` + `matchScore`); nothing is auto-confirmed. An admin
+/// resolves each PENDING row in the Zuordnungs-Queue: confirming materializes
+/// the billable WORK Event (`resolvedEventId`) and a ChildVertretung record, so
+/// an unresolved report never reaches billing/export.
+model VertretungRequest {
+  id               String                  @id @default(cuid())
+  reportedByUserId String
+  childNameText    String
+  date             DateTime                @db.Date
+  startTime        String
+  endTime          String
+  note             String?                 @db.Text
+  signatureKey     String
+  status           VertretungRequestStatus @default(PENDING)
+  suggestedChildId String?
+  matchScore       Float?
+  resolvedChildId  String?
+  resolvedByUserId String?
+  resolvedEventId  String?
+  resolvedAt       DateTime?
+  rejectionReason  String?                 @db.Text
+  createdAt        DateTime                @default(now())
+  updatedAt        DateTime                @updatedAt
+  reportedByUser   User                    @relation("VertretungRequestReporter", fields: [reportedByUserId], references: [id], onDelete: Cascade)
+  suggestedChild   Child?                  @relation("VertretungRequestSuggestedChild", fields: [suggestedChildId], references: [id], onDelete: SetNull)
+
+  @@index([status])
+  @@index([reportedByUserId])
+  @@map("vertretung_request")
 }
 
 model Kostentraeger {

--- a/src/app/admin/handlungsbedarf/page.tsx
+++ b/src/app/admin/handlungsbedarf/page.tsx
@@ -1,5 +1,16 @@
 import { ChildrenFacade, HandlungsbedarfDashboard } from "@/features/children";
 import { SchoolAssistantsFacade } from "@/features/school-assistants";
+import {
+  VertretungQueue,
+  VertretungRequestsFacade,
+} from "@/features/vertretung-requests";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { parseIsoDate, startOfWeekUtc, todayIsoBerlin } from "@/lib/dates";
 import { formatIsoDateUtc } from "@/lib/utils";
 
@@ -10,18 +21,54 @@ export default async function HandlungsbedarfPage() {
     startOfWeekUtc(parseIsoDate(todayIsoBerlin())),
   );
 
-  const [result, schoolAssistants] = await Promise.all([
-    ChildrenFacade.getHandlungsbedarf(weekStartIso),
-    SchoolAssistantsFacade.list(),
-  ]);
+  const [result, schoolAssistants, pendingRequests, children] =
+    await Promise.all([
+      ChildrenFacade.getHandlungsbedarf(weekStartIso),
+      SchoolAssistantsFacade.list(),
+      VertretungRequestsFacade.listPending(),
+      ChildrenFacade.list(),
+    ]);
+
+  // Roster for the admin's child picker — admin-only, never sent to the
+  // reporting Schulbegleiter (Datenschutz). Map to plain fields so no Prisma
+  // Decimal/relation reaches the client component.
+  const childOptions = children.map((c) => ({
+    id: c.id,
+    firstName: c.firstName,
+    lastName: c.lastName,
+  }));
 
   return (
-    <HandlungsbedarfDashboard
-      initialResult={result}
-      initialWeekStartIso={weekStartIso}
-      schoolAssistantOptions={schoolAssistants
-        .filter((p) => !!p.userId)
-        .map((p) => ({ id: p.userId as string, name: p.name }))}
-    />
+    <div className="space-y-6">
+      <HandlungsbedarfDashboard
+        initialResult={result}
+        initialWeekStartIso={weekStartIso}
+        schoolAssistantOptions={schoolAssistants
+          .filter((p) => !!p.userId)
+          .map((p) => ({ id: p.userId as string, name: p.name }))}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            Zuzuordnen{" "}
+            <span className="text-muted-foreground">
+              ({pendingRequests.length})
+            </span>
+          </CardTitle>
+          <CardDescription>
+            Von Schulbegleitern gemeldete Vertretungen mit Freitext-Kind. Das
+            korrekte Kind zuordnen, um den Eintrag zu bestätigen — erst danach
+            zählt er zur Abrechnung.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <VertretungQueue
+            requests={pendingRequests}
+            childOptions={childOptions}
+          />
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -13,16 +13,23 @@ import {
   type UpdateChildInput,
   WorkEventSchema,
   UpdateWorkEventSchema,
+  SignedWorkEventSchema,
+  SubstitutionRecordSchema,
   type UpdateVertretungInput,
   type VertretungInput,
   type WorkEventInput,
   type UpdateWorkEventInput,
+  type SignedWorkEventInput,
+  type SubstitutionRecordInput,
+  type ChildMatchResult,
 } from "./schemas";
 import {
   createAssignment,
   createChild,
   createSchedule,
+  createSignedWorkEvent,
   createVertretungBlocks,
+  rankChildrenByName,
   deleteAbsenceById,
   deleteAssignmentById,
   deleteChildById,
@@ -232,6 +239,62 @@ export const ChildrenFacade = {
       substituteUserId: parsed.substituteUserId,
       date,
       timeBlocks,
+    });
+  },
+
+  /**
+   * Fuzzy-match a free-text child name against the roster (COD-51). Returns a
+   * *suggestion* only — never auto-links. `suggestedChildId` is set only when
+   * the best candidate clears the confidence threshold AND is clearly ahead of
+   * the runner-up; otherwise it stays null and an admin must pick the child.
+   * The roster never leaves the server, so this is safe to call before a
+   * companion's report is shown to anyone.
+   */
+  async matchChildByFreeText(text: string): Promise<ChildMatchResult> {
+    const SUGGEST_THRESHOLD = 0.82;
+    const AMBIGUOUS_DELTA = 0.08;
+
+    const candidates = await rankChildrenByName(text, 5);
+    const best = candidates[0];
+    const runnerUp = candidates[1];
+
+    let suggestedChildId: string | null = null;
+    if (best && best.score >= SUGGEST_THRESHOLD) {
+      const ambiguous = runnerUp
+        ? best.score - runnerUp.score < AMBIGUOUS_DELTA
+        : false;
+      if (!ambiguous) suggestedChildId = best.childId;
+    }
+
+    return {
+      suggestedChildId,
+      matchScore: best?.score ?? null,
+      candidates,
+    };
+  },
+
+  /**
+   * Create a WORK event that carries the Schulbegleiter's own signature.
+   * Used when an admin confirms a Vertretung-Request — the companion already
+   * signed at report time, so the materialised entry is billable at once.
+   */
+  async createSignedWorkEvent(input: SignedWorkEventInput) {
+    const parsed = SignedWorkEventSchema.parse(input);
+    return createSignedWorkEvent(parsed);
+  },
+
+  /**
+   * Materialise a substitution record (ChildVertretung) from a confirmed
+   * Vertretung-Request. Unlike {@link createVertretung}, the times are the ones
+   * the companion actually reported, not copied from the Stundenplan.
+   */
+  async createSubstitutionRecord(input: SubstitutionRecordInput) {
+    const parsed = SubstitutionRecordSchema.parse(input);
+    await createVertretungBlocks({
+      childId: parsed.childId,
+      substituteUserId: parsed.substituteUserId,
+      date: new Date(`${parsed.date}T00:00:00.000Z`),
+      timeBlocks: [{ startTime: parsed.startTime, endTime: parsed.endTime }],
     });
   },
 

--- a/src/features/children/index.ts
+++ b/src/features/children/index.ts
@@ -6,6 +6,8 @@ export type {
   ScheduleInput,
   SchoolInput,
   UpdateChildInput,
+  ChildMatchCandidate,
+  ChildMatchResult,
 } from "./schemas";
 export {
   serializeChild,

--- a/src/features/children/schemas.ts
+++ b/src/features/children/schemas.ts
@@ -139,6 +139,49 @@ export const UpdateVertretungSchema = z.object({
 });
 export type UpdateVertretungInput = z.infer<typeof UpdateVertretungSchema>;
 
+// Result of fuzzy-matching a free-text child name against the roster. Used by
+// the Vertretung-Request flow (COD-51). `suggestedChildId` is only set when the
+// best candidate clears the confidence threshold and is unambiguous; the full
+// `candidates` list is for the admin queue only and never reaches a companion.
+export type ChildMatchCandidate = {
+  childId: string;
+  firstName: string;
+  lastName: string;
+  score: number;
+};
+
+export type ChildMatchResult = {
+  suggestedChildId: string | null;
+  matchScore: number | null;
+  candidates: ChildMatchCandidate[];
+};
+
+// A WORK event created on behalf of a Schulbegleiter that carries their
+// existing signature (captured when they reported the Vertretung). Distinct
+// from WorkEventSchema, whose admin-created events start unsigned.
+export const SignedWorkEventSchema = z.object({
+  childId: z.string().min(1),
+  userId: z.string().min(1),
+  date: dateString,
+  startTime: timeString,
+  endTime: timeString,
+  note: optionalText(2000),
+  signatureKey: z.string().min(1),
+});
+export type SignedWorkEventInput = z.infer<typeof SignedWorkEventSchema>;
+
+// A substitution record materialised from a confirmed Vertretung-Request. Unlike
+// VertretungSchema (admin-planned, times copied from the Stundenplan), the times
+// here are the ones the companion actually reported.
+export const SubstitutionRecordSchema = z.object({
+  childId: z.string().min(1),
+  substituteUserId: z.string().min(1),
+  date: dateString,
+  startTime: timeString,
+  endTime: timeString,
+});
+export type SubstitutionRecordInput = z.infer<typeof SubstitutionRecordSchema>;
+
 // Kinder-Wizard UI state types — kept here per AGENTS.md ("Zod schemas and TS types").
 
 export type SchoolValue = {

--- a/src/features/children/services/events.ts
+++ b/src/features/children/services/events.ts
@@ -1,6 +1,10 @@
 import { prisma } from "@/lib/prisma";
 import { EventType, type Prisma } from "@/generated/prisma";
-import type { WorkEventInput, UpdateWorkEventInput } from "../schemas";
+import type {
+  WorkEventInput,
+  UpdateWorkEventInput,
+  SignedWorkEventInput,
+} from "../schemas";
 
 export type ChildWorkEvent = Prisma.EventGetPayload<{
   include: { user: true };
@@ -26,6 +30,27 @@ export async function createWorkEventAsAdmin(input: WorkEventInput) {
       startTime: input.startTime,
       endTime: input.endTime,
       note: input.note ?? null,
+    },
+  });
+}
+
+/**
+ * Create a WORK event that is already signed by the Schulbegleiter. Used when
+ * an admin confirms a Vertretung-Request: the companion signed at report time,
+ * so the resulting entry carries that signature (non-null `signatureKey` →
+ * "signed by the Schulbegleiter") and counts toward billing immediately.
+ */
+export async function createSignedWorkEvent(input: SignedWorkEventInput) {
+  return prisma.event.create({
+    data: {
+      childId: input.childId,
+      userId: input.userId,
+      type: EventType.WORK,
+      date: new Date(`${input.date}T00:00:00.000Z`),
+      startTime: input.startTime,
+      endTime: input.endTime,
+      note: input.note ?? null,
+      signatureKey: input.signatureKey,
     },
   });
 }

--- a/src/features/children/services/index.ts
+++ b/src/features/children/services/index.ts
@@ -4,3 +4,4 @@ export * from "./schedules";
 export * from "./absences";
 export * from "./events";
 export * from "./vertretung";
+export * from "./matching";

--- a/src/features/children/services/matching.ts
+++ b/src/features/children/services/matching.ts
@@ -1,0 +1,30 @@
+import { prisma } from "@/lib/prisma";
+import { nameSimilarity } from "@/lib/fuzzy";
+import type { ChildMatchCandidate } from "../schemas";
+
+/**
+ * Score every child against a free-text name and return the best `limit`
+ * candidates, highest score first. "Dumb" data access + pure scoring — the
+ * confidence threshold / suggestion decision lives in the facade.
+ */
+export async function rankChildrenByName(
+  query: string,
+  limit = 5,
+): Promise<ChildMatchCandidate[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const children = await prisma.child.findMany({
+    select: { id: true, firstName: true, lastName: true },
+  });
+
+  return children
+    .map((c) => ({
+      childId: c.id,
+      firstName: c.firstName,
+      lastName: c.lastName,
+      score: nameSimilarity(trimmed, `${c.firstName} ${c.lastName}`),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { EventType, type Schedule } from "@/generated/prisma";
 import { SignaturePadDialog } from "./signature-pad-dialog";
 import { createEventAction } from "../actions";
+import { submitVertretungRequestAction } from "@/features/vertretung-requests/actions";
 import {
   formatDuration,
   parseIsoDate,
@@ -28,6 +29,10 @@ import type { ChildOption } from "./children-filter";
 import { childIdsForDate, type AssignmentsByWeekday } from "../weekday";
 import { cn, formatIsoDateUtc } from "@/lib/utils";
 import type { VertretungDay } from "./timesheet-shell";
+
+/** UI entry mode. VERTRETUNG is a free-text substitution report (COD-51) and is
+ * NOT an EventType — it becomes a pending VertretungRequest, not an Event. */
+type EntryMode = "WORK" | "VERTRETUNG" | "SICK";
 
 type LastEntry = {
   startTime: string | null;
@@ -64,6 +69,44 @@ function addMinutes(time: string, minutes: number): string {
   return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
 }
 
+function TimeRangeInputs({
+  startTime,
+  endTime,
+  onStartChange,
+  onEndChange,
+}: {
+  startTime: string;
+  endTime: string;
+  onStartChange: (v: string) => void;
+  onEndChange: (v: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-[1fr_auto_1fr] gap-2 items-end">
+      <div className="space-y-1.5">
+        <Label htmlFor="start">Start</Label>
+        <Input
+          id="start"
+          type="time"
+          value={startTime}
+          onChange={(e) => onStartChange(e.target.value)}
+          className="h-14 text-xl font-mono tabular-nums"
+        />
+      </div>
+      <span className="pb-3 text-muted-foreground">→</span>
+      <div className="space-y-1.5">
+        <Label htmlFor="end">Ende</Label>
+        <Input
+          id="end"
+          type="time"
+          value={endTime}
+          onChange={(e) => onEndChange(e.target.value)}
+          className="h-14 text-xl font-mono tabular-nums"
+        />
+      </div>
+    </div>
+  );
+}
+
 export function NewEntrySheet({
   open,
   onOpenChange,
@@ -75,11 +118,12 @@ export function NewEntrySheet({
   lastEntry,
   substituteOn = [],
 }: Props) {
-  const [type, setType] = useState<EventType>(EventType.WORK);
+  const [mode, setMode] = useState<EntryMode>("WORK");
   const [date, setDate] = useState(formatIsoDateUtc(defaultDate));
   const [startTime, setStartTime] = useState("08:00");
   const [endTime, setEndTime] = useState("17:00");
   const [note, setNote] = useState("");
+  const [childNameText, setChildNameText] = useState("");
 
   // Vertretungen for the currently selected date
   const dayVertretungen = useMemo(
@@ -108,10 +152,11 @@ export function NewEntrySheet({
   useEffect(() => {
     if (open) {
       setDate(formatIsoDateUtc(defaultDate));
-      setType(EventType.WORK);
+      setMode("WORK");
       setStartTime("08:00");
       setEndTime("17:00");
       setNote("");
+      setChildNameText("");
     }
   }, [open, defaultDate]);
 
@@ -136,7 +181,11 @@ export function NewEntrySheet({
   }, [startTime, endTime]);
 
   const canProceed =
-    type === EventType.SICK ? true : childIds.length >= 1 && Boolean(duration);
+    mode === "SICK"
+      ? true
+      : mode === "VERTRETUNG"
+        ? childNameText.trim().length >= 2 && Boolean(duration)
+        : childIds.length >= 1 && Boolean(duration);
 
   const toggleChild = (id: string) => {
     setChildIds((cur) =>
@@ -213,22 +262,34 @@ export function NewEntrySheet({
   const submitWithSignature = async (pngBase64: string) => {
     setSubmitting(true);
     try {
-      await createEventAction({
-        type,
-        date,
-        childIds: type === EventType.WORK ? childIds : [],
-        startTime: type === EventType.WORK ? startTime : undefined,
-        endTime: type === EventType.WORK ? endTime : undefined,
-        note: note.trim() || undefined,
-        signaturePngBase64: pngBase64,
-      });
-      toast.success(
-        type === EventType.WORK
-          ? `Eintrag gespeichert (${childIds.length} Kind${
-              childIds.length === 1 ? "" : "er"
-            })`
-          : "Krankheit gespeichert",
-      );
+      if (mode === "VERTRETUNG") {
+        await submitVertretungRequestAction({
+          childNameText: childNameText.trim(),
+          date,
+          startTime,
+          endTime,
+          note: note.trim() || undefined,
+          signaturePngBase64: pngBase64,
+        });
+        toast.success("Vertretung gemeldet — wird vom Team zugeordnet.");
+      } else {
+        await createEventAction({
+          type: mode === "SICK" ? EventType.SICK : EventType.WORK,
+          date,
+          childIds: mode === "WORK" ? childIds : [],
+          startTime: mode === "WORK" ? startTime : undefined,
+          endTime: mode === "WORK" ? endTime : undefined,
+          note: note.trim() || undefined,
+          signaturePngBase64: pngBase64,
+        });
+        toast.success(
+          mode === "WORK"
+            ? `Eintrag gespeichert (${childIds.length} Kind${
+                childIds.length === 1 ? "" : "er"
+              })`
+            : "Krankheit gespeichert",
+        );
+      }
       setSigOpen(false);
       onOpenChange(false);
     } catch (e: unknown) {
@@ -239,9 +300,16 @@ export function NewEntrySheet({
   };
 
   const signerSubtitle =
-    type === EventType.WORK
-      ? `${date} · ${startTime}–${endTime}${duration ? ` · ${duration}` : ""}`
-      : `${date} · Krank · ganztägig`;
+    mode === "SICK"
+      ? `${date} · Krank · ganztägig`
+      : `${date} · ${startTime}–${endTime}${duration ? ` · ${duration}` : ""}`;
+
+  const signerTitle =
+    mode === "VERTRETUNG"
+      ? "Vertretung bestätigen"
+      : mode === "WORK"
+        ? "Arbeitszeit bestätigen"
+        : "Krankheit bestätigen";
 
   return (
     <>
@@ -279,22 +347,34 @@ export function NewEntrySheet({
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-3 gap-2">
               <Button
                 type="button"
-                variant={type === EventType.WORK ? "default" : "outline"}
-                onClick={() => setType(EventType.WORK)}
-                className="h-12"
+                variant={mode === "WORK" ? "default" : "outline"}
+                onClick={() => setMode("WORK")}
+                className="h-12 flex-col gap-1 text-xs"
               >
                 <Briefcase className="size-4" /> Arbeit
               </Button>
               <Button
                 type="button"
-                variant={type === EventType.SICK ? "default" : "outline"}
-                onClick={() => setType(EventType.SICK)}
+                variant={mode === "VERTRETUNG" ? "default" : "outline"}
+                onClick={() => setMode("VERTRETUNG")}
                 className={cn(
-                  "h-12",
-                  type === EventType.SICK &&
+                  "h-12 flex-col gap-1 text-xs",
+                  mode === "VERTRETUNG" &&
+                    "bg-amber-500 hover:bg-amber-600 text-white",
+                )}
+              >
+                <UserCheck className="size-4" /> Vertretung
+              </Button>
+              <Button
+                type="button"
+                variant={mode === "SICK" ? "default" : "outline"}
+                onClick={() => setMode("SICK")}
+                className={cn(
+                  "h-12 flex-col gap-1 text-xs",
+                  mode === "SICK" &&
                     "bg-rose-600 hover:bg-rose-700 text-white",
                 )}
               >
@@ -302,7 +382,7 @@ export function NewEntrySheet({
               </Button>
             </div>
 
-            {type === EventType.WORK && (
+            {mode === "WORK" && (
               <>
                 {dayAssignedChildren.length === 0 ? (
                   <p className="rounded-lg border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
@@ -358,29 +438,12 @@ export function NewEntrySheet({
                   </div>
                 )}
 
-                <div className="grid grid-cols-[1fr_auto_1fr] gap-2 items-end">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="start">Start</Label>
-                    <Input
-                      id="start"
-                      type="time"
-                      value={startTime}
-                      onChange={(e) => setStartTime(e.target.value)}
-                      className="h-14 text-xl font-mono tabular-nums"
-                    />
-                  </div>
-                  <span className="pb-3 text-muted-foreground">→</span>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="end">Ende</Label>
-                    <Input
-                      id="end"
-                      type="time"
-                      value={endTime}
-                      onChange={(e) => setEndTime(e.target.value)}
-                      className="h-14 text-xl font-mono tabular-nums"
-                    />
-                  </div>
-                </div>
+                <TimeRangeInputs
+                  startTime={startTime}
+                  endTime={endTime}
+                  onStartChange={setStartTime}
+                  onEndChange={setEndTime}
+                />
 
                 <p className="text-sm text-muted-foreground">
                   {duration
@@ -416,6 +479,38 @@ export function NewEntrySheet({
               </>
             )}
 
+            {mode === "VERTRETUNG" && (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="childName">Name des Kindes</Label>
+                  <Input
+                    id="childName"
+                    value={childNameText}
+                    onChange={(e) => setChildNameText(e.target.value)}
+                    placeholder="Vor- und Nachname"
+                    autoComplete="off"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Bitte den Namen frei eintippen. Die genaue Zuordnung
+                    übernimmt das Team.
+                  </p>
+                </div>
+
+                <TimeRangeInputs
+                  startTime={startTime}
+                  endTime={endTime}
+                  onStartChange={setStartTime}
+                  onEndChange={setEndTime}
+                />
+
+                <p className="text-sm text-muted-foreground">
+                  {duration
+                    ? `Dauer: ${duration}`
+                    : "Ende muss nach Start liegen"}
+                </p>
+              </>
+            )}
+
             <div className="space-y-1.5">
               <Label htmlFor="note">Notiz (optional)</Label>
               <Textarea
@@ -423,9 +518,9 @@ export function NewEntrySheet({
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
                 placeholder={
-                  type === EventType.WORK
-                    ? "z.B. besondere Vorkommnisse"
-                    : "z.B. Arzttermin"
+                  mode === "SICK"
+                    ? "z.B. Arzttermin"
+                    : "z.B. besondere Vorkommnisse"
                 }
                 rows={3}
               />
@@ -453,11 +548,7 @@ export function NewEntrySheet({
       <SignaturePadDialog
         open={sigOpen}
         onOpenChange={setSigOpen}
-        title={
-          type === EventType.WORK
-            ? "Arbeitszeit bestätigen"
-            : "Krankheit bestätigen"
-        }
+        title={signerTitle}
         subtitle={signerSubtitle}
         signerLabel={`${currentUserName} (Mitarbeiter)`}
         onConfirm={submitWithSignature}

--- a/src/features/vertretung-requests/actions.ts
+++ b/src/features/vertretung-requests/actions.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAdmin, requireAuth } from "@/lib/auth-guards";
+import { VertretungRequestsFacade } from "./facade";
+import { submitVertretungRequest } from "@/use-cases/submit-vertretung-request";
+import { resolveVertretungRequest } from "@/use-cases/resolve-vertretung-request";
+import type {
+  RejectVertretungRequestInput,
+  ResolveVertretungRequestInput,
+  SubmitVertretungRequestInput,
+} from "./schemas";
+
+/** Schulbegleiter reports a Vertretung for a child they are not assigned to. */
+export async function submitVertretungRequestAction(
+  input: SubmitVertretungRequestInput,
+) {
+  const { id: userId } = await requireAuth();
+  await submitVertretungRequest(userId, input);
+  revalidatePath("/");
+}
+
+/** Admin lists all pending reports awaiting child assignment. */
+export async function listPendingVertretungRequestsAction() {
+  await requireAdmin();
+  return VertretungRequestsFacade.listPending();
+}
+
+/** Admin confirms a report by assigning the correct child. */
+export async function confirmVertretungRequestAction(
+  input: ResolveVertretungRequestInput,
+) {
+  const { id: adminId } = await requireAdmin();
+  await resolveVertretungRequest(adminId, input);
+  revalidatePath("/admin/children");
+  revalidatePath("/");
+}
+
+/** Admin rejects a report (single-feature → facade directly per AGENTS.md). */
+export async function rejectVertretungRequestAction(
+  input: RejectVertretungRequestInput,
+) {
+  const { id: adminId } = await requireAdmin();
+  await VertretungRequestsFacade.markRejected(input.requestId, {
+    resolvedByUserId: adminId,
+    reason: input.reason?.trim() || null,
+  });
+  revalidatePath("/admin/children");
+}

--- a/src/features/vertretung-requests/components/vertretung-queue.tsx
+++ b/src/features/vertretung-requests/components/vertretung-queue.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Check, ChevronsUpDown, UserCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import {
+  confirmVertretungRequestAction,
+  rejectVertretungRequestAction,
+} from "../actions";
+import type { SerializedVertretungRequest } from "../serialize";
+
+export type QueueChildOption = {
+  id: string;
+  firstName: string;
+  lastName: string;
+};
+
+type Props = {
+  requests: SerializedVertretungRequest[];
+  /** Full roster — admin-only; never exposed to the reporting companion. */
+  childOptions: QueueChildOption[];
+};
+
+function formatGermanDate(iso: string): string {
+  const [y, m, d] = iso.split("-");
+  return `${d}.${m}.${y}`;
+}
+
+/**
+ * Admin resolution queue ("Zuzuordnen") for Schulbegleiter-reported
+ * Vertretungen with a free-text child name (COD-51). Self-contained: pass the
+ * pending `requests` and the `childOptions` roster as props so it can be mounted
+ * directly into COD-50's "Handlungsbedarf" tab.
+ */
+export function VertretungQueue({ requests, childOptions }: Props) {
+  if (requests.length === 0) {
+    return (
+      <p className="rounded-lg border border-border bg-muted/40 px-3 py-6 text-center text-sm text-muted-foreground">
+        Keine offenen Vertretungs-Meldungen.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {requests.map((request) => (
+        <QueueRow
+          key={request.id}
+          request={request}
+          childOptions={childOptions}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function QueueRow({
+  request,
+  childOptions,
+}: {
+  request: SerializedVertretungRequest;
+  childOptions: QueueChildOption[];
+}) {
+  const router = useRouter();
+  const [childId, setChildId] = useState<string | null>(
+    request.suggestedChildId,
+  );
+  const [busy, setBusy] = useState(false);
+  const [rejecting, setRejecting] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const matchPercent =
+    request.matchScore != null ? Math.round(request.matchScore * 100) : null;
+
+  async function handleConfirm() {
+    if (!childId) {
+      toast.error("Bitte zuerst ein Kind auswählen.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await confirmVertretungRequestAction({
+        requestId: request.id,
+        childId,
+      });
+      toast.success("Vertretung zugeordnet und Eintrag erstellt.");
+      router.refresh();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Zuordnen fehlgeschlagen.",
+      );
+      setBusy(false);
+    }
+  }
+
+  async function handleReject() {
+    setBusy(true);
+    try {
+      await rejectVertretungRequestAction({
+        requestId: request.id,
+        reason: reason.trim() || undefined,
+      });
+      toast.success("Meldung abgelehnt.");
+      router.refresh();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Ablehnen fehlgeschlagen.",
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <li className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <UserCheck className="size-4 shrink-0 text-amber-600" />
+            <span className="truncate text-sm font-semibold">
+              „{request.childNameText}“
+            </span>
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Gemeldet von {request.reportedByUserName} ·{" "}
+            {formatGermanDate(request.date)} · {request.startTime}–
+            {request.endTime}
+          </p>
+          {request.note ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Notiz: {request.note}
+            </p>
+          ) : null}
+        </div>
+        {request.suggestedChildName ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
+            Vorschlag: {request.suggestedChildName}
+            {matchPercent != null ? ` · ${matchPercent}%` : ""}
+          </span>
+        ) : (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Kein eindeutiger Treffer
+          </span>
+        )}
+      </div>
+
+      {rejecting ? (
+        <div className="mt-3 space-y-2">
+          <Label
+            htmlFor={`reason-${request.id}`}
+            className="text-xs text-muted-foreground"
+          >
+            Grund (optional)
+          </Label>
+          <Textarea
+            id={`reason-${request.id}`}
+            rows={2}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="z.B. kein passendes Kind im Bestand"
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setRejecting(false)}
+              disabled={busy}
+            >
+              Zurück
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={handleReject}
+              disabled={busy}
+            >
+              {busy ? "…" : "Ablehnen bestätigen"}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-end">
+          <div className="min-w-0 flex-1 space-y-1">
+            <Label className="text-xs text-muted-foreground">Kind</Label>
+            <ChildCombobox
+              options={childOptions}
+              value={childId}
+              onChange={setChildId}
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setRejecting(true)}
+              disabled={busy}
+            >
+              Ablehnen
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleConfirm}
+              disabled={busy || !childId}
+            >
+              {busy ? "Speichert…" : "Bestätigen"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function ChildCombobox({
+  options,
+  value,
+  onChange,
+}: {
+  options: QueueChildOption[];
+  value: string | null;
+  onChange: (id: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = useMemo(
+    () => options.find((o) => o.id === value) ?? null,
+    [options, value],
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          size="sm"
+          className="h-9 w-full justify-between font-normal"
+          disabled={options.length === 0}
+        >
+          <span className={cn(!selected && "text-muted-foreground")}>
+            {selected
+              ? `${selected.firstName} ${selected.lastName}`
+              : "Kind auswählen…"}
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Kind suchen…" />
+          <CommandList>
+            <CommandEmpty>Keine Treffer.</CommandEmpty>
+            <CommandGroup>
+              {options.map((o) => (
+                <CommandItem
+                  key={o.id}
+                  value={`${o.firstName} ${o.lastName}`}
+                  onSelect={() => {
+                    onChange(o.id === value ? null : o.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 size-4",
+                      value === o.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {o.firstName} {o.lastName}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from "node:crypto";
+import {
+  createVertretungRequestRow,
+  getVertretungRequestById,
+  listPendingVertretungRequests,
+  markVertretungRequestConfirmed,
+  markVertretungRequestRejected,
+  uploadVertretungSignature,
+} from "./services";
+import {
+  serializeVertretungRequest,
+  type SerializedVertretungRequest,
+} from "./serialize";
+import type { CreateVertretungRequestData } from "./schemas";
+
+/**
+ * Feature brain for Schulbegleiter-reported substitutions (COD-51). Owns the
+ * VertretungRequest table only — fuzzy matching against the roster and the
+ * materialisation of the confirmed Event/ChildVertretung are coordinated by
+ * use-cases (cross-feature). Stays free of auth/HTTP per AGENTS.md.
+ */
+export const VertretungRequestsFacade = {
+  /**
+   * Persist a companion's free-text report together with the server-derived
+   * match suggestion. The companion's signature is uploaded here; the row
+   * starts PENDING and is invisible to billing until an admin confirms it.
+   */
+  async createRequest(data: CreateVertretungRequestData) {
+    const signatureKey = `signatures/vertretung/${data.reportedByUserId}/${randomUUID()}.png`;
+    await uploadVertretungSignature(signatureKey, data.signaturePngBase64);
+
+    return createVertretungRequestRow({
+      reportedByUserId: data.reportedByUserId,
+      childNameText: data.childNameText,
+      date: new Date(`${data.date}T00:00:00.000Z`),
+      startTime: data.startTime,
+      endTime: data.endTime,
+      note: data.note ?? null,
+      signatureKey,
+      suggestedChildId: data.suggestedChildId,
+      matchScore: data.matchScore,
+    });
+  },
+
+  async listPending(): Promise<SerializedVertretungRequest[]> {
+    const rows = await listPendingVertretungRequests();
+    return rows.map(serializeVertretungRequest);
+  },
+
+  /** Raw row — used by the resolve use-case to materialise the Event. */
+  async getRequest(id: string) {
+    return getVertretungRequestById(id);
+  },
+
+  async markConfirmed(
+    id: string,
+    data: {
+      resolvedChildId: string;
+      resolvedByUserId: string;
+      resolvedEventId: string;
+    },
+  ) {
+    return markVertretungRequestConfirmed(id, data);
+  },
+
+  async markRejected(
+    id: string,
+    data: { resolvedByUserId: string; reason: string | null },
+  ) {
+    return markVertretungRequestRejected(id, data);
+  },
+};

--- a/src/features/vertretung-requests/index.ts
+++ b/src/features/vertretung-requests/index.ts
@@ -1,0 +1,14 @@
+export { VertretungRequestsFacade } from "./facade";
+export {
+  VertretungQueue,
+  type QueueChildOption,
+} from "./components/vertretung-queue";
+export {
+  serializeVertretungRequest,
+  type SerializedVertretungRequest,
+} from "./serialize";
+export type {
+  SubmitVertretungRequestInput,
+  ResolveVertretungRequestInput,
+  RejectVertretungRequestInput,
+} from "./schemas";

--- a/src/features/vertretung-requests/schemas.ts
+++ b/src/features/vertretung-requests/schemas.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+const timeStringSchema = z.string().regex(/^\d{2}:\d{2}$/, "Ungültige Zeit.");
+
+const dateStringSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Ungültiges Datum.");
+
+const signatureSchema = z
+  .string()
+  .min(100, "Unterschrift fehlt.")
+  .refine(
+    (v) => v.startsWith("data:image/") || /^[A-Za-z0-9+/=\n\r]+$/.test(v),
+    "Ungültige Signatur.",
+  );
+
+/**
+ * A Schulbegleiter reporting a Vertretung for a child they are NOT assigned to.
+ * The child is free text (`childNameText`) — the roster is never shown to them.
+ * Times are entered manually (no Stundenplan link to a foreign child).
+ */
+export const SubmitVertretungRequestSchema = z
+  .object({
+    childNameText: z
+      .string()
+      .trim()
+      .min(2, "Bitte den Namen des Kindes eingeben.")
+      .max(200),
+    date: dateStringSchema,
+    startTime: timeStringSchema,
+    endTime: timeStringSchema,
+    note: z.string().max(2000).optional(),
+    signaturePngBase64: signatureSchema,
+  })
+  .refine((v) => v.endTime > v.startTime, {
+    message: "Ende muss nach Start liegen.",
+    path: ["endTime"],
+  });
+
+export type SubmitVertretungRequestInput = z.infer<
+  typeof SubmitVertretungRequestSchema
+>;
+
+/** Admin confirms a pending request by assigning the correct child. */
+export const ResolveVertretungRequestSchema = z.object({
+  requestId: z.string().min(1),
+  childId: z.string().min(1, "Bitte ein Kind auswählen."),
+});
+
+export type ResolveVertretungRequestInput = z.infer<
+  typeof ResolveVertretungRequestSchema
+>;
+
+/** Admin rejects a pending request (e.g. not a real child, duplicate). */
+export const RejectVertretungRequestSchema = z.object({
+  requestId: z.string().min(1),
+  reason: z.string().trim().max(2000).optional(),
+});
+
+export type RejectVertretungRequestInput = z.infer<
+  typeof RejectVertretungRequestSchema
+>;
+
+/** Data the facade persists when creating a request (server-derived match). */
+export type CreateVertretungRequestData = {
+  reportedByUserId: string;
+  childNameText: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  note?: string;
+  signaturePngBase64: string;
+  suggestedChildId: string | null;
+  matchScore: number | null;
+};

--- a/src/features/vertretung-requests/serialize.ts
+++ b/src/features/vertretung-requests/serialize.ts
@@ -1,0 +1,38 @@
+import type { PendingVertretungRequest } from "./services";
+
+/** UI-safe shape of a pending Vertretung-Request for the admin queue. */
+export type SerializedVertretungRequest = {
+  id: string;
+  childNameText: string;
+  reportedByUserId: string;
+  reportedByUserName: string;
+  date: string; // yyyy-mm-dd
+  startTime: string;
+  endTime: string;
+  note: string | null;
+  suggestedChildId: string | null;
+  suggestedChildName: string | null;
+  matchScore: number | null;
+  createdAt: string; // ISO
+};
+
+export function serializeVertretungRequest(
+  row: PendingVertretungRequest,
+): SerializedVertretungRequest {
+  return {
+    id: row.id,
+    childNameText: row.childNameText,
+    reportedByUserId: row.reportedByUserId,
+    reportedByUserName: row.reportedByUser.name,
+    date: row.date.toISOString().slice(0, 10),
+    startTime: row.startTime,
+    endTime: row.endTime,
+    note: row.note,
+    suggestedChildId: row.suggestedChildId,
+    suggestedChildName: row.suggestedChild
+      ? `${row.suggestedChild.firstName} ${row.suggestedChild.lastName}`
+      : null,
+    matchScore: row.matchScore,
+    createdAt: row.createdAt.toISOString(),
+  };
+}

--- a/src/features/vertretung-requests/services/index.ts
+++ b/src/features/vertretung-requests/services/index.ts
@@ -1,0 +1,77 @@
+import { prisma } from "@/lib/prisma";
+import { uploadSignaturePng } from "@/lib/storage";
+import { VertretungRequestStatus, type Prisma } from "@/generated/prisma";
+
+export type PendingVertretungRequest = Prisma.VertretungRequestGetPayload<{
+  include: { reportedByUser: true; suggestedChild: true };
+}>;
+
+export async function uploadVertretungSignature(
+  key: string,
+  pngBase64: string,
+) {
+  return uploadSignaturePng(key, pngBase64);
+}
+
+export async function createVertretungRequestRow(data: {
+  reportedByUserId: string;
+  childNameText: string;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  note: string | null;
+  signatureKey: string;
+  suggestedChildId: string | null;
+  matchScore: number | null;
+}) {
+  return prisma.vertretungRequest.create({ data });
+}
+
+export async function listPendingVertretungRequests(): Promise<
+  PendingVertretungRequest[]
+> {
+  return prisma.vertretungRequest.findMany({
+    where: { status: VertretungRequestStatus.PENDING },
+    include: { reportedByUser: true, suggestedChild: true },
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+export async function getVertretungRequestById(id: string) {
+  return prisma.vertretungRequest.findUnique({ where: { id } });
+}
+
+export async function markVertretungRequestConfirmed(
+  id: string,
+  data: {
+    resolvedChildId: string;
+    resolvedByUserId: string;
+    resolvedEventId: string;
+  },
+) {
+  return prisma.vertretungRequest.update({
+    where: { id },
+    data: {
+      status: VertretungRequestStatus.CONFIRMED,
+      resolvedChildId: data.resolvedChildId,
+      resolvedByUserId: data.resolvedByUserId,
+      resolvedEventId: data.resolvedEventId,
+      resolvedAt: new Date(),
+    },
+  });
+}
+
+export async function markVertretungRequestRejected(
+  id: string,
+  data: { resolvedByUserId: string; reason: string | null },
+) {
+  return prisma.vertretungRequest.update({
+    where: { id },
+    data: {
+      status: VertretungRequestStatus.REJECTED,
+      resolvedByUserId: data.resolvedByUserId,
+      rejectionReason: data.reason,
+      resolvedAt: new Date(),
+    },
+  });
+}

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -1,0 +1,105 @@
+/**
+ * Dependency-free fuzzy string matching for German names.
+ *
+ * Used to match a free-text child name typed by a Schulbegleiter against the
+ * child roster (see `ChildrenFacade.matchChildByFreeText`). Kept here in `lib/`
+ * as cross-cutting infrastructure: it is pure string math with no domain or DB
+ * knowledge, so any layer may use it.
+ *
+ * `nameSimilarity` returns a score in [0, 1] that is robust to umlaut spelling
+ * (Müller ≈ Mueller), diacritics, punctuation, casing, and word order
+ * (Max Mustermann ≈ Mustermann, Max).
+ */
+
+/**
+ * Normalise a name for comparison: lowercase, expand German umlauts/ß to their
+ * ASCII digraphs, strip remaining diacritics and punctuation, collapse spaces.
+ */
+export function normalizeName(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/ä/g, "ae")
+    .replace(/ö/g, "oe")
+    .replace(/ü/g, "ue")
+    .replace(/ß/g, "ss")
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function sortTokens(normalized: string): string {
+  return normalized.split(" ").filter(Boolean).sort().join(" ");
+}
+
+function bigramCounts(value: string): Map<string, number> {
+  const compact = value.replace(/\s+/g, "");
+  const counts = new Map<string, number>();
+  for (let i = 0; i < compact.length - 1; i++) {
+    const bigram = compact.slice(i, i + 2);
+    counts.set(bigram, (counts.get(bigram) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Sørensen–Dice coefficient over character bigrams, in [0, 1]. */
+export function diceCoefficient(a: string, b: string): number {
+  if (a === b) return 1;
+  if (a.length < 2 || b.length < 2) return 0;
+  const ba = bigramCounts(a);
+  const bb = bigramCounts(b);
+  let total = 0;
+  let overlap = 0;
+  for (const count of ba.values()) total += count;
+  for (const count of bb.values()) total += count;
+  for (const [bigram, count] of ba) {
+    overlap += Math.min(count, bb.get(bigram) ?? 0);
+  }
+  return total === 0 ? 0 : (2 * overlap) / total;
+}
+
+/** Levenshtein edit distance (iterative, two-row). */
+export function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  let curr = new Array<number>(n + 1);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+/** Levenshtein similarity normalised to [0, 1]. */
+export function levenshteinRatio(a: string, b: string): number {
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshtein(a, b) / maxLen;
+}
+
+/**
+ * Combined similarity of two names in [0, 1]. Compares both as-is and with
+ * tokens sorted (so first/last-name order does not matter), taking the best of
+ * the Dice coefficient and the Levenshtein ratio.
+ */
+export function nameSimilarity(a: string, b: string): number {
+  const na = normalizeName(a);
+  const nb = normalizeName(b);
+  if (!na || !nb) return 0;
+  if (na === nb) return 1;
+
+  const direct = Math.max(diceCoefficient(na, nb), levenshteinRatio(na, nb));
+  const sa = sortTokens(na);
+  const sb = sortTokens(nb);
+  const reordered = Math.max(diceCoefficient(sa, sb), levenshteinRatio(sa, sb));
+
+  return Math.max(direct, reordered);
+}

--- a/src/use-cases/resolve-vertretung-request.ts
+++ b/src/use-cases/resolve-vertretung-request.ts
@@ -1,0 +1,69 @@
+/**
+ * Use case: an admin resolves a pending Vertretung-Request by assigning the
+ * correct child (COD-51).
+ *
+ * On confirmation it materialises, in the children domain:
+ *  1. A billable WORK Event carrying the companion's original signature
+ *     (createSignedWorkEvent) — so the entry counts toward billing only now,
+ *     after admin confirmation.
+ *  2. A ChildVertretung substitution record with the reported times
+ *     (createSubstitutionRecord) — the same record an admin would create
+ *     manually, keeping the children calendar consistent.
+ * It then marks the request CONFIRMED.
+ *
+ * Coordinates ChildrenFacade and VertretungRequestsFacade, so it lives as a
+ * cross-feature use case rather than inside either facade.
+ */
+
+import { ChildrenFacade } from "@/features/children/facade";
+import { VertretungRequestsFacade } from "@/features/vertretung-requests/facade";
+import {
+  ResolveVertretungRequestSchema,
+  type ResolveVertretungRequestInput,
+} from "@/features/vertretung-requests/schemas";
+
+export async function resolveVertretungRequest(
+  adminId: string,
+  input: ResolveVertretungRequestInput,
+) {
+  const parsed = ResolveVertretungRequestSchema.parse(input);
+
+  const request = await VertretungRequestsFacade.getRequest(parsed.requestId);
+  if (!request) {
+    throw new Error("Vertretungsmeldung nicht gefunden.");
+  }
+  if (request.status !== "PENDING") {
+    throw new Error("Diese Meldung wurde bereits bearbeitet.");
+  }
+
+  const dateStr = request.date.toISOString().slice(0, 10);
+
+  // 1. Billable WORK event, signed by the reporting Schulbegleiter.
+  const event = await ChildrenFacade.createSignedWorkEvent({
+    childId: parsed.childId,
+    userId: request.reportedByUserId,
+    date: dateStr,
+    startTime: request.startTime,
+    endTime: request.endTime,
+    note: request.note ?? undefined,
+    signatureKey: request.signatureKey,
+  });
+
+  // 2. Substitution record with the times the companion actually reported.
+  await ChildrenFacade.createSubstitutionRecord({
+    childId: parsed.childId,
+    substituteUserId: request.reportedByUserId,
+    date: dateStr,
+    startTime: request.startTime,
+    endTime: request.endTime,
+  });
+
+  // 3. Mark the request resolved.
+  await VertretungRequestsFacade.markConfirmed(parsed.requestId, {
+    resolvedChildId: parsed.childId,
+    resolvedByUserId: adminId,
+    resolvedEventId: event.id,
+  });
+
+  return event;
+}

--- a/src/use-cases/submit-vertretung-request.ts
+++ b/src/use-cases/submit-vertretung-request.ts
@@ -1,0 +1,42 @@
+/**
+ * Use case: a Schulbegleiter reports a Vertretung for a child they are NOT
+ * assigned to (COD-51).
+ *
+ * Coordinates two feature facades:
+ *  1. ChildrenFacade.matchChildByFreeText — fuzzy-match the free-text child name
+ *     against the roster, server-side only (the roster is never shown to the
+ *     companion for Datenschutz reasons).
+ *  2. VertretungRequestsFacade.createRequest — store the report PENDING, with
+ *     the suggestion attached, awaiting admin resolution.
+ *
+ * The match suggestion is never auto-confirmed: nothing reaches billing until
+ * an admin resolves the request.
+ */
+
+import { ChildrenFacade } from "@/features/children/facade";
+import { VertretungRequestsFacade } from "@/features/vertretung-requests/facade";
+import {
+  SubmitVertretungRequestSchema,
+  type SubmitVertretungRequestInput,
+} from "@/features/vertretung-requests/schemas";
+
+export async function submitVertretungRequest(
+  userId: string,
+  input: SubmitVertretungRequestInput,
+) {
+  const parsed = SubmitVertretungRequestSchema.parse(input);
+
+  const match = await ChildrenFacade.matchChildByFreeText(parsed.childNameText);
+
+  return VertretungRequestsFacade.createRequest({
+    reportedByUserId: userId,
+    childNameText: parsed.childNameText,
+    date: parsed.date,
+    startTime: parsed.startTime,
+    endTime: parsed.endTime,
+    note: parsed.note,
+    signaturePngBase64: parsed.signaturePngBase64,
+    suggestedChildId: match.suggestedChildId,
+    matchScore: match.matchScore,
+  });
+}


### PR DESCRIPTION
Implements **COD-51** — the part beyond COD-30: server-side fuzzy matching of a free-text child name + an admin resolution queue.

> **Stacked on #41 (`feature/cod-50`).** Base this PR on `feature/cod-50`; review only the COD-51 commit. Re-target to `main` once #41 merges.

## Flow
A Schulbegleiter reports a Vertretung for a child they are **not** assigned to → types the child name as **free text** (Datenschutz: the roster is never shown, no suggestions) → the server fuzzy-matches it against the roster → an admin resolves it in the **"Zuzuordnen"** section of the Handlungsbedarf tab. Confirming materialises the billable `WORK` `Event` (carrying the companion's signature) **and** a `ChildVertretung`.

## Key decisions (confirmed with @go69tes)
- **No new `EventType`.** A new `VertretungRequest` table holds the free-text report + match state. On confirm it materialises both an `Event` and a `ChildVertretung` (the same record an admin creates manually).
- **Billing is gated automatically:** no `Event` exists until an admin confirms, so an unresolved report can never reach billing/export.
- **Times are entered manually** by the companion (no Stundenplan link to a foreign child); they carry onto the Event + ChildVertretung at confirm.
- Matching **suggests only** — never auto-confirms.

## Changes
- New feature `src/features/vertretung-requests/` (model, services, facade, serializer, actions, `VertretungQueue` component).
- `lib/fuzzy.ts` — dependency-free name similarity (umlaut/diacritic/word-order tolerant). Roster ranking in a children service; threshold decision in `ChildrenFacade.matchChildByFreeText`.
- Cross-feature use-cases `submit-vertretung-request` and `resolve-vertretung-request`.
- Third **"Vertretung"** mode in the timesheet new-entry sheet (free text + manual time + signature).
- `VertretungQueue` mounted in `/admin/handlungsbedarf` as the "Zuzuordnen" card (composed at the app layer; children ↔ vertretung-requests stay decoupled).
- Docs: `ARCHITECTURE.md` + dependency graph updated.

## Notes for the reviewer
- **Migration `20260603160000_add_vertretung_request` is hand-authored** (mirrors the existing style; `prisma generate` succeeds). Please run `npm run db:migrate` against a dev DB to apply and confirm no drift.
- **Companions can't yet see their own pending reports** (no `Event` until confirmed, by design). An "in Prüfung" list for companions is a deliberate follow-up, out of scope here.

## Verification
`tsc --noEmit`, `npm run lint` (incl. `eslint-plugin-boundaries`), and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)