### PR TITLE
COD-49: (Schulbegleiter) Kind krank melden

### DIFF
--- a/prisma/migrations/20260603160744_child_absence_created_by/migration.sql
+++ b/prisma/migrations/20260603160744_child_absence_created_by/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE `child_absence` ADD COLUMN `createdByUserId` VARCHAR(191) NULL;
+
+-- CreateIndex
+CREATE INDEX `child_absence_createdByUserId_idx` ON `child_absence`(`createdByUserId`);
+
+-- AddForeignKey
+ALTER TABLE `child_absence` ADD CONSTRAINT `child_absence_createdByUserId_fkey` FOREIGN KEY (`createdByUserId`) REFERENCES `user`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   monthlyReports MonthlyReport[]
   profile       SchoolAssistantProfile?
   vertretungenAsSubstitute  ChildVertretung[] @relation("SubstituteVertretung")
+  reportedChildAbsences     ChildAbsence[]    @relation("ReportedChildAbsences")
 
   @@unique([email])
   @@map("user")
@@ -190,11 +191,17 @@ model ChildAbsence {
   childId   String
   date      DateTime @db.Date
   note      String?  @db.Text
+  // Who reported the absence. NULL -> created by an admin (via /admin/children);
+  // non-null -> reported by a Schulbegleiter for an assigned child. Used to scope
+  // who may revoke it. onDelete: SetNull keeps the absence if the reporter is removed.
+  createdByUserId String?
   createdAt DateTime @default(now())
-  child     Child    @relation(fields: [childId], references: [id], onDelete: Cascade)
+  child         Child  @relation(fields: [childId], references: [id], onDelete: Cascade)
+  createdByUser User?  @relation("ReportedChildAbsences", fields: [createdByUserId], references: [id], onDelete: SetNull)
 
   @@unique([childId, date])
   @@index([childId, date])
+  @@index([createdByUserId])
   @@map("child_absence")
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { getSession } from "@/lib/auth-guards";
 import { redirect } from "next/navigation";
 import { isAdmin } from "@/lib/roles";
+import { isSameUtcDay } from "@/lib/dates";
 import { TimesheetFacade, SchoolAssistantApp } from "@/features/timesheet";
 import { SchoolAssistantsFacade } from "@/features/school-assistants";
 import { ChildrenFacade } from "@/features/children";
@@ -72,9 +73,14 @@ export default async function LandingPage() {
       schedules={schedules}
       lockedMonthKeys={lockedMonthKeys}
       childAbsences={childAbsences.map((a) => ({
+        id: a.id,
         childId: a.childId,
         date: a.date.toISOString().slice(0, 10),
         note: a.note,
+        // The reporter may take it back until the end of the day they reported
+        // it. Computed server-side; the action re-checks authoritatively.
+        canRevoke:
+          a.createdByUserId === user.id && isSameUtcDay(today, a.createdAt),
       }))}
       assignmentsByWeekday={assignmentsByWeekday}
       substituteOn={vertretungenAsSubstitute.map((v) => ({

--- a/src/features/children/actions.ts
+++ b/src/features/children/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { requireAdmin } from "@/lib/auth-guards";
+import { requireAdmin, requireAuth } from "@/lib/auth-guards";
 import { ChildrenFacade } from "./facade";
 import type {
   AbsenceInput,
@@ -103,6 +103,28 @@ export async function deleteAbsenceAction(id: string) {
   await requireAdmin();
   await ChildrenFacade.deleteAbsence(id);
   revalidatePath(ROUTE);
+  return { success: true as const };
+}
+
+// A Schulbegleiter reports one of their assigned children sick from the home
+// page. Access is enforced inside the facade (assigned/Vertretung on the date).
+export async function reportChildSickAction(input: AbsenceInput) {
+  const { id: userId } = await requireAuth();
+  await ChildrenFacade.reportChildSick(userId, input);
+  revalidatePath("/"); // Schulbegleiter home
+  revalidatePath(ROUTE); // admin children view
+  revalidatePath("/admin/map"); // map hides absent children
+  return { success: true as const };
+}
+
+// A Schulbegleiter takes back a sick report they made (same-day window enforced
+// in the facade). Admins still revoke any absence via deleteAbsenceAction.
+export async function revokeChildSickAction(absenceId: string) {
+  const { id: userId } = await requireAuth();
+  await ChildrenFacade.revokeChildSick(userId, absenceId);
+  revalidatePath("/");
+  revalidatePath(ROUTE);
+  revalidatePath("/admin/map");
   return { success: true as const };
 }
 

--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -24,6 +24,8 @@ import {
   createSchedule,
   createVertretungBlocks,
   deleteAbsenceById,
+  findAbsenceById,
+  reportChildAbsence,
   deleteAssignmentById,
   deleteChildById,
   deleteScheduleById,
@@ -52,6 +54,47 @@ import {
   deleteWorkEventAsAdmin,
   restoreWorkEventAsAdmin,
 } from "./services";
+import { isSameUtcDay } from "@/lib/dates";
+
+/**
+ * Shared access guard: verifies that every childId is either regularly assigned
+ * to userId on that weekday OR covered by a Vertretung for that specific date.
+ * Throws if any child is uncovered. Kept as a module-level helper so both the
+ * public facade method and the Schulbegleiter sick-report path reuse it.
+ */
+async function assertChildrenAccess(
+  userId: string,
+  childIds: string[],
+  date: Date,
+) {
+  if (childIds.length === 0) return;
+
+  // Mon=0..Sun=6, matching Schedule.weekday convention.
+  const weekday = (date.getUTCDay() + 6) % 7;
+  const coveredByAssignment = await getAssignmentCoverage(
+    userId,
+    childIds,
+    weekday,
+  );
+
+  const uncovered = childIds.filter((id) => !coveredByAssignment.has(id));
+  if (uncovered.length === 0) return;
+
+  // Normalise to UTC midnight to match @db.Date semantics.
+  const dateOnly = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const coveredByVertretung = await getVertretungCoverage(
+    userId,
+    uncovered,
+    dateOnly,
+  );
+
+  const stillUncovered = uncovered.filter((id) => !coveredByVertretung.has(id));
+  if (stillUncovered.length > 0) {
+    throw new Error("Ein Kind ist diesem Konto nicht zugewiesen.");
+  }
+}
 
 function childFieldsFromCreate(input: CreateChildInput) {
   return {
@@ -268,35 +311,46 @@ export const ChildrenFacade = {
     childIds: string[],
     date: Date,
   ) {
-    if (childIds.length === 0) return;
+    return assertChildrenAccess(userId, childIds, date);
+  },
 
-    // Mon=0..Sun=6, matching Schedule.weekday convention.
-    const weekday = (date.getUTCDay() + 6) % 7;
-    const coveredByAssignment = await getAssignmentCoverage(
-      userId,
-      childIds,
-      weekday,
-    );
+  /**
+   * A Schulbegleiter reports a single assigned child sick for a date. Verifies
+   * the child is assigned to (or covered by a Vertretung of) the user on that
+   * date, then writes a ChildAbsence stamped with the reporter. Idempotent if
+   * the child is already marked absent. No auth/session context here — the
+   * caller (action) resolves the userId via the auth guards.
+   */
+  async reportChildSick(userId: string, input: AbsenceInput) {
+    const parsed = AbsenceSchema.parse(input);
+    const date = new Date(`${parsed.date}T00:00:00.000Z`);
+    await assertChildrenAccess(userId, [parsed.childId], date);
+    return reportChildAbsence({
+      childId: parsed.childId,
+      date,
+      note: parsed.note ?? null,
+      createdByUserId: userId,
+    });
+  },
 
-    const uncovered = childIds.filter((id) => !coveredByAssignment.has(id));
-    if (uncovered.length === 0) return;
-
-    // Normalise to UTC midnight to match @db.Date semantics.
-    const dateOnly = new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-    );
-    const coveredByVertretung = await getVertretungCoverage(
-      userId,
-      uncovered,
-      dateOnly,
-    );
-
-    const stillUncovered = uncovered.filter(
-      (id) => !coveredByVertretung.has(id),
-    );
-    if (stillUncovered.length > 0) {
-      throw new Error("Ein Kind ist diesem Konto nicht zugewiesen.");
+  /**
+   * A Schulbegleiter revokes a child sick report they made. Only the reporter
+   * may revoke, and only until the end of the (UTC) day on which it was
+   * reported. Admin-created absences (createdByUserId === null) and reports by
+   * other users are rejected — admins remove those via the admin children view.
+   */
+  async revokeChildSick(userId: string, absenceId: string) {
+    const absence = await findAbsenceById(absenceId);
+    if (!absence) throw new Error("Krankmeldung nicht gefunden.");
+    if (absence.createdByUserId !== userId) {
+      throw new Error("Diese Krankmeldung kann nicht zurückgenommen werden.");
     }
+    if (!isSameUtcDay(new Date(), absence.createdAt)) {
+      throw new Error(
+        "Eine Krankmeldung kann nur am selben Tag zurückgenommen werden.",
+      );
+    }
+    await deleteAbsenceById(absenceId);
   },
 
   async createWorkEventAsAdmin(input: WorkEventInput) {

--- a/src/features/children/services/absences.ts
+++ b/src/features/children/services/absences.ts
@@ -34,6 +34,30 @@ export async function upsertAbsence(data: {
   });
 }
 
+/**
+ * Records a Schulbegleiter-reported absence. Idempotent: if the child is
+ * already marked absent for that date — whether by an admin or a previous
+ * report — the existing row is kept untouched (the update is a no-op) so an
+ * admin-created entry is never clobbered. `createdByUserId` is only stamped on
+ * first creation, which is what scopes the revoke permission to the reporter.
+ */
+export async function reportChildAbsence(data: {
+  childId: string;
+  date: Date;
+  note: string | null;
+  createdByUserId: string;
+}) {
+  return prisma.childAbsence.upsert({
+    where: { childId_date: { childId: data.childId, date: data.date } },
+    create: data,
+    update: {},
+  });
+}
+
+export async function findAbsenceById(id: string) {
+  return prisma.childAbsence.findUnique({ where: { id } });
+}
+
 export async function deleteAbsenceById(id: string) {
   await prisma.childAbsence.delete({ where: { id } });
 }

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -390,8 +390,8 @@ export function NewEntrySheet({
                 </div>
                 {dayAssignedChildren.length === 0 ? (
                   <p className="text-xs text-muted-foreground">
-                    An diesem Tag ist dir kein Kind zugewiesen — nur deine eigene
-                    Krankmeldung ist möglich.
+                    An diesem Tag ist dir kein Kind zugewiesen — nur deine
+                    eigene Krankmeldung ist möglich.
                   </p>
                 ) : sickSubject !== "self" ? (
                   <p className="text-xs text-muted-foreground">

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Briefcase, Stethoscope, UserCheck } from "lucide-react";
+import { Baby, Briefcase, Stethoscope, UserCheck } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { EventType, type Schedule } from "@/generated/prisma";
 import { SignaturePadDialog } from "./signature-pad-dialog";
 import { createEventAction } from "../actions";
+import { reportChildSickAction } from "@/features/children/actions";
 import {
   formatDuration,
   parseIsoDate,
@@ -102,6 +103,10 @@ export function NewEntrySheet({
   const [childIds, setChildIds] = useState<string[]>(
     dayAssignedChildren.length === 1 ? [dayAssignedChildren[0].id] : [],
   );
+  // For type=SICK: who is sick — the Schulbegleiter ("self") or one assigned
+  // child (the child's id). Self keeps the unchanged own-sick (signed) flow;
+  // a child id triggers a ChildAbsence report.
+  const [sickSubject, setSickSubject] = useState<"self" | string>("self");
   const [sigOpen, setSigOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
@@ -109,11 +114,22 @@ export function NewEntrySheet({
     if (open) {
       setDate(formatIsoDateUtc(defaultDate));
       setType(EventType.WORK);
+      setSickSubject("self");
       setStartTime("08:00");
       setEndTime("17:00");
       setNote("");
     }
   }, [open, defaultDate]);
+
+  // Drop a child selection that is no longer valid for the day (e.g. after a
+  // date change) so the sick report can never target an unassigned child.
+  useEffect(() => {
+    setSickSubject((prev) =>
+      prev === "self" || dayAssignedChildren.some((c) => c.id === prev)
+        ? prev
+        : "self",
+    );
+  }, [dayAssignedChildren]);
 
   // Whenever the day's assigned children change (open, date change, or
   // the underlying data updates), preselect the only one if applicable
@@ -210,6 +226,28 @@ export function NewEntrySheet({
     dayVertretungen,
   ]);
 
+  // A child sick report writes a ChildAbsence directly — no signature required.
+  const submitChildSick = async () => {
+    if (sickSubject === "self") return;
+    setSubmitting(true);
+    try {
+      await reportChildSickAction({
+        childId: sickSubject,
+        date,
+        note: note.trim() || undefined,
+      });
+      const child = dayAssignedChildren.find((c) => c.id === sickSubject);
+      toast.success(
+        child ? `${child.firstName} krank gemeldet` : "Kind krank gemeldet",
+      );
+      onOpenChange(false);
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Speichern fehlgeschlagen.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const submitWithSignature = async (pngBase64: string) => {
     setSubmitting(true);
     try {
@@ -264,7 +302,14 @@ export function NewEntrySheet({
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              if (canProceed && !submitting) setSigOpen(true);
+              if (!canProceed || submitting) return;
+              // A child sick report saves immediately; everything else
+              // (work entry, own sick) is confirmed with a signature.
+              if (type === EventType.SICK && sickSubject !== "self") {
+                void submitChildSick();
+              } else {
+                setSigOpen(true);
+              }
             }}
             className="px-4 pb-6 space-y-4"
           >
@@ -301,6 +346,61 @@ export function NewEntrySheet({
                 <Stethoscope className="size-4" /> Krank
               </Button>
             </div>
+
+            {type === EventType.SICK && (
+              <div className="space-y-1.5">
+                <Label>Wer ist krank?</Label>
+                <div className="grid grid-cols-1 gap-1.5">
+                  <Button
+                    type="button"
+                    variant={sickSubject === "self" ? "default" : "outline"}
+                    onClick={() => setSickSubject("self")}
+                    className={cn(
+                      "h-11 justify-start",
+                      sickSubject === "self" &&
+                        "bg-rose-600 hover:bg-rose-700 text-white",
+                    )}
+                  >
+                    <Stethoscope className="size-4" /> Ich (eigene Krankmeldung)
+                  </Button>
+                  {dayAssignedChildren.map((c) => (
+                    <Button
+                      key={c.id}
+                      type="button"
+                      variant={sickSubject === c.id ? "default" : "outline"}
+                      onClick={() => setSickSubject(c.id)}
+                      className={cn(
+                        "h-11 justify-start",
+                        sickSubject === c.id &&
+                          "bg-rose-600 hover:bg-rose-700 text-white",
+                      )}
+                    >
+                      <Baby className="size-4" />
+                      <span className="flex-1 text-left">
+                        {c.firstName} {c.lastName}
+                      </span>
+                      {dayVertretungen.some((v) => v.childId === c.id) && (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
+                          <UserCheck className="size-3" />
+                          Vertretung
+                        </span>
+                      )}
+                    </Button>
+                  ))}
+                </div>
+                {dayAssignedChildren.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    An diesem Tag ist dir kein Kind zugewiesen — nur deine eigene
+                    Krankmeldung ist möglich.
+                  </p>
+                ) : sickSubject !== "self" ? (
+                  <p className="text-xs text-muted-foreground">
+                    Wird ohne Unterschrift gespeichert und ist für die
+                    Verwaltung sichtbar.
+                  </p>
+                ) : null}
+              </div>
+            )}
 
             {type === EventType.WORK && (
               <>
@@ -441,9 +541,11 @@ export function NewEntrySheet({
               </Button>
               <Button
                 type="submit"
-                disabled={!canProceed}
+                disabled={!canProceed || submitting}
               >
-                Speichern & signieren
+                {type === EventType.SICK && sickSubject !== "self"
+                  ? "Kind krank melden"
+                  : "Speichern & signieren"}
               </Button>
             </div>
           </form>

--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/dates";
 import { WeekStrip } from "./week-strip";
 import { deleteEventAction } from "../actions";
+import { revokeChildSickAction } from "@/features/children/actions";
 import type { Event, Schedule } from "@/generated/prisma";
 import type { ChildOption } from "./children-filter";
 import type { ChildAbsenceItem, VertretungDay } from "./timesheet-shell";
@@ -173,6 +174,20 @@ export function TabDay({
     }
   };
 
+  const handleRevokeAbsence = async (id: string) => {
+    setBusyId(id);
+    try {
+      await revokeChildSickAction(id);
+      toast.success("Krankmeldung zurückgenommen.");
+    } catch (e: unknown) {
+      toast.error(
+        e instanceof Error ? e.message : "Zurücknehmen fehlgeschlagen.",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <WeekStrip
@@ -215,27 +230,36 @@ export function TabDay({
             <div className="grid place-items-center size-10 shrink-0 rounded-full bg-rose-500/15 text-rose-700">
               <Stethoscope className="size-5" />
             </div>
-            <div className="flex-1 space-y-1">
+            <div className="flex-1 space-y-2">
               <p className="font-semibold text-rose-900">
                 {dayAbsences.length === 1
-                  ? `${dayAbsences[0].child.firstName} ${dayAbsences[0].child.lastName} ist krank gemeldet`
+                  ? "Kind krank gemeldet"
                   : `${dayAbsences.length} zugewiesene Kinder sind krank gemeldet`}
               </p>
-              {dayAbsences.length > 1 && (
-                <ul className="text-sm text-rose-900/80">
-                  {dayAbsences.map((a) => (
-                    <li key={a.childId}>
+              <ul className="space-y-1.5">
+                {dayAbsences.map((a) => (
+                  <li
+                    key={a.id}
+                    className="flex items-center gap-2 text-sm text-rose-900/90"
+                  >
+                    <span className="flex-1">
                       {a.child.firstName} {a.child.lastName}
                       {a.note ? ` — ${a.note}` : ""}
-                    </li>
-                  ))}
-                </ul>
-              )}
-              {dayAbsences.length === 1 && dayAbsences[0].note && (
-                <p className="text-sm text-rose-900/80">
-                  {dayAbsences[0].note}
-                </p>
-              )}
+                    </span>
+                    {a.canRevoke && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 px-2 text-rose-700 hover:text-rose-900"
+                        onClick={() => handleRevokeAbsence(a.id)}
+                        disabled={busyId === a.id}
+                      >
+                        Zurücknehmen
+                      </Button>
+                    )}
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
         </Card>

--- a/src/features/timesheet/components/timesheet-shell.tsx
+++ b/src/features/timesheet/components/timesheet-shell.tsx
@@ -48,7 +48,11 @@ type EventWithChild = Event & {
 
 // Date-Spalte ist `@db.Date`; serialisiert als YYYY-MM-DD über die RSC-Grenze.
 export type ChildAbsenceItem = Pick<ChildAbsence, "childId" | "note"> & {
+  id: string;
   date: string;
+  // True when the current Schulbegleiter reported it and is still within the
+  // same-day window — i.e. may take it back from the day view.
+  canRevoke: boolean;
 };
 
 export type VertretungDay = {


### PR DESCRIPTION
## COD-49 — (Schulbegleiter) Kind krank melden

Lets a Schulbegleiter report an **assigned** child sick for a date from the home page (writes a `ChildAbsence`). The existing **"Krank"** button now asks *who is sick*:

- **Ich** → the unchanged, **signed** self-sick `Event` (`type=SICK`).
- **A zugewiesenes Kind** → writes a `ChildAbsence`, **no signature** (per product decision).

Reporting a child sick is **independent** of the aide's own day entry. Single child, single day.

### Architecture (single-feature → Action calls the `children` Facade directly; no use-case)
- **Schema**: `ChildAbsence.createdByUserId` (nullable, `onDelete: SetNull`, indexed) records who reported it. Admin-created absences stay `null`; this scopes who may revoke. Migration `child_absence_created_by`.
- **Service** (`children/services/absences.ts`): `reportChildAbsence` — idempotent upsert (`update: {}`) that never clobbers an existing/admin row; `findAbsenceById`.
- **Facade** (`children/facade.ts`): `reportChildSick` reuses the assignment/Vertretung access guard (refactored into a shared `assertChildrenAccess` helper); `revokeChildSick` enforces own-report + same-UTC-day window.
- **Actions** (`children/actions.ts`): `reportChildSickAction` / `revokeChildSickAction` with `requireAuth`; revalidate `/`, `/admin/children`, `/admin/map`.
- **UI**: `NewEntrySheet` "Wer ist krank?" self/child selector (child path skips signature); `TabDay` per-child **"Zurücknehmen"** button within the window. Home page maps `id` + server-computed `canRevoke`.

### Decisions
- **Revoke**: admin always (existing `/admin/children`); aide only their own report, until the **end of the (UTC) day** it was reported.
- No effect on the aide's own timesheet entry; no signature for the child report (own sick keeps its signature).

### Notes / for review
- Revoke window uses **same-UTC-day** to match the codebase's uniform UTC day convention (`@db.Date`, weekday math) rather than Berlin-local end-of-day — near local midnight this can differ by an hour or two. Flagging in case strict local end-of-day is preferred.
- Branch is `worktree-feature+cod-49` (this repo's worktree convention); title carries `COD-49` for Linear linking.

### Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (incl. boundaries)
- [x] `npm run build` succeeds
- [ ] Manual: as a Schulbegleiter, "Krank" → pick an assigned child → saved & visible in admin `/admin/children`; revoke same day; own sick still signs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
