### PR TITLE
Feature/vertretung freitext matching

### DIFF
--- a/prisma/migrations/20260606111119_add_pending_vertretung_request/migration.sql
+++ b/prisma/migrations/20260606111119_add_pending_vertretung_request/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE `pending_vertretung_request` (
+    `id` VARCHAR(191) NOT NULL,
+    `substituteUserId` VARCHAR(191) NOT NULL,
+    `childNameText` VARCHAR(191) NOT NULL,
+    `date` DATE NOT NULL,
+    `startTime` VARCHAR(191) NOT NULL,
+    `endTime` VARCHAR(191) NOT NULL,
+    `signatureKey` VARCHAR(191) NOT NULL,
+    `matchedChildId` VARCHAR(191) NULL,
+    `matchConfidence` DOUBLE NULL,
+    `status` ENUM('PENDING', 'RESOLVED', 'REJECTED') NOT NULL DEFAULT 'PENDING',
+    `resolvedChildId` VARCHAR(191) NULL,
+    `resolvedAt` DATETIME(3) NULL,
+    `resolvedByUserId` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `pending_vertretung_request_substituteUserId_status_idx`(`substituteUserId`, `status`),
+    INDEX `pending_vertretung_request_status_date_idx`(`status`, `date`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `pending_vertretung_request` ADD CONSTRAINT `pending_vertretung_request_substituteUserId_fkey` FOREIGN KEY (`substituteUserId`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `pending_vertretung_request` ADD CONSTRAINT `pending_vertretung_request_resolvedChildId_fkey` FOREIGN KEY (`resolvedChildId`) REFERENCES `child`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `pending_vertretung_request` ADD CONSTRAINT `pending_vertretung_request_resolvedByUserId_fkey` FOREIGN KEY (`resolvedByUserId`) REFERENCES `user`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260611171352_drop_event_is_substitute/migration.sql
+++ b/prisma/migrations/20260611171352_drop_event_is_substitute/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: drop the isSubstitute flag — the Einspringen flow is being
+-- replaced by the dedicated Vertretung request feature, so the column is no
+-- longer written or read by application code.
+ALTER TABLE `event` DROP COLUMN `isSubstitute`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -230,7 +230,6 @@ model Event {
   startTime    String?
   endTime      String?
   note         String?   @db.Text
-  isSubstitute Boolean   @default(false)
   signatureKey String?   // !null -> by school assistant, null -> by admin
   deleted      Boolean   @default(false) // soft delete only for signed events; admin-created events are hard deleted
   createdAt    DateTime  @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,12 @@ enum SchulbegleiterStatus {
   ACCEPTED
 }
 
+enum PendingVertretungStatus {
+  PENDING
+  RESOLVED
+  REJECTED
+}
+
 model User {
   id            String    @id
   name          String
@@ -42,7 +48,9 @@ model User {
   events        Event[]
   monthlyReports MonthlyReport[]
   profile       SchoolAssistantProfile?
-  vertretungenAsSubstitute  ChildVertretung[] @relation("SubstituteVertretung")
+  vertretungenAsSubstitute    ChildVertretung[]            @relation("SubstituteVertretung")
+  pendingVertretungRequests   PendingVertretungRequest[]   @relation("PendingVertretungSubstitute")
+  resolvedVertretungRequests  PendingVertretungRequest[]   @relation("PendingVertretungResolver")
 
   @@unique([email])
   @@map("user")
@@ -131,8 +139,9 @@ model Child {
   assignments                ChildAssignment[]
   schedules                  Schedule[]
   events                     Event[]
-  absences                   ChildAbsence[]
-  vertretungen               ChildVertretung[]
+  absences                    ChildAbsence[]
+  vertretungen                ChildVertretung[]
+  pendingVertretungRequests   PendingVertretungRequest[]
 
   @@index([kostentraegerId])
   @@map("child")
@@ -289,4 +298,28 @@ model WorkshopAttendance {
   @@unique([workshopId, profileId])
   @@index([profileId])
   @@map("workshop_attendance")
+}
+
+model PendingVertretungRequest {
+  id               String                  @id @default(cuid())
+  substituteUserId String
+  childNameText    String
+  date             DateTime                @db.Date
+  startTime        String
+  endTime          String
+  signatureKey     String
+  matchedChildId   String?
+  matchConfidence  Float?
+  status           PendingVertretungStatus @default(PENDING)
+  resolvedChildId  String?
+  resolvedAt       DateTime?
+  resolvedByUserId String?
+  createdAt        DateTime                @default(now())
+  substituteUser   User                    @relation("PendingVertretungSubstitute", fields: [substituteUserId], references: [id], onDelete: Cascade)
+  resolvedChild    Child?                  @relation(fields: [resolvedChildId], references: [id], onDelete: SetNull)
+  resolvedByUser   User?                   @relation("PendingVertretungResolver", fields: [resolvedByUserId], references: [id], onDelete: SetNull)
+
+  @@index([substituteUserId, status])
+  @@index([status, date])
+  @@map("pending_vertretung_request")
 }

--- a/src/app/admin/_components/nav-items.ts
+++ b/src/app/admin/_components/nav-items.ts
@@ -3,6 +3,7 @@ import {
   BookOpen,
   Home,
   ShieldCheck,
+  TriangleAlert,
   Users,
   type LucideIcon,
 } from "lucide-react";
@@ -38,6 +39,12 @@ export const NAV_ITEMS: readonly NavItem[] = [
     label: "Workshops",
     description: "Fortbildungen anlegen und planen.",
     icon: BookOpen,
+  },
+  {
+    href: "/admin/handlungsbedarf",
+    label: "Handlungsbedarf",
+    description: "Offene Vertretungs-Anträge zuordnen.",
+    icon: TriangleAlert,
   },
 ];
 

--- a/src/app/admin/handlungsbedarf/page.tsx
+++ b/src/app/admin/handlungsbedarf/page.tsx
@@ -18,8 +18,6 @@ export default async function HandlungsbedarfPage() {
     date: r.date.toISOString().slice(0, 10),
     startTime: r.startTime,
     endTime: r.endTime,
-    matchedChildId: r.matchedChildId,
-    matchConfidence: r.matchConfidence,
     substituteUser: r.substituteUser,
   }));
 

--- a/src/app/admin/handlungsbedarf/page.tsx
+++ b/src/app/admin/handlungsbedarf/page.tsx
@@ -1,0 +1,49 @@
+import { requireAdmin } from "@/lib/auth-guards";
+import { VertretungRequestsFacade } from "@/features/vertretung-requests";
+import { ChildrenFacade } from "@/features/children";
+import { PendingRequestsTable } from "@/features/vertretung-requests/components/pending-requests-table";
+import { PageSection } from "@/components/page-section";
+
+export default async function HandlungsbedarfPage() {
+  await requireAdmin();
+
+  const [rawRequests, children] = await Promise.all([
+    VertretungRequestsFacade.listPending(),
+    ChildrenFacade.list(),
+  ]);
+
+  const requests = rawRequests.map((r) => ({
+    id: r.id,
+    childNameText: r.childNameText,
+    date: r.date.toISOString().slice(0, 10),
+    startTime: r.startTime,
+    endTime: r.endTime,
+    matchedChildId: r.matchedChildId,
+    matchConfidence: r.matchConfidence,
+    substituteUser: r.substituteUser,
+  }));
+
+  const childOptions = children.map((c) => ({
+    id: c.id,
+    firstName: c.firstName,
+    lastName: c.lastName,
+  }));
+
+  return (
+    <div className="space-y-8 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Handlungsbedarf</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Vertretungs-Anträge, die noch einem Kind zugeordnet werden müssen.
+        </p>
+      </div>
+
+      <PageSection title={`Zuzuordnen (${requests.length})`}>
+        <PendingRequestsTable
+          requests={requests}
+          childOptions={childOptions}
+        />
+      </PageSection>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,14 +80,22 @@ export default async function LandingPage() {
         note: a.note,
       }))}
       assignmentsByWeekday={assignmentsByWeekday}
-      substituteOn={vertretungenAsSubstitute.map((v) => ({
-        id: v.id,
-        date: v.date.toISOString().slice(0, 10),
-        childId: v.childId,
-        childName: `${v.child.firstName} ${v.child.lastName}`,
-        startTime: v.startTime,
-        endTime: v.endTime,
-      }))}
+      substituteOn={vertretungenAsSubstitute.map((v) => {
+        const sbRequest = pendingVertretungRequests.find(
+          (r) =>
+            r.date.getTime() === v.date.getTime() &&
+            (r.matchedChildId === v.childId || r.resolvedChildId === v.childId),
+        );
+        return {
+          id: v.id,
+          date: v.date.toISOString().slice(0, 10),
+          childId: v.childId,
+          childName: `${v.child.firstName} ${v.child.lastName}`,
+          startTime: v.startTime,
+          endTime: v.endTime,
+          sbRequestId: sbRequest?.id ?? null,
+        };
+      })}
       pendingVertretungRequests={pendingVertretungRequests.map((r) => ({
         id: r.id,
         date: r.date.toISOString().slice(0, 10),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { isAdmin } from "@/lib/roles";
 import { TimesheetFacade, SchoolAssistantApp } from "@/features/timesheet";
 import { SchoolAssistantsFacade } from "@/features/school-assistants";
 import { ChildrenFacade } from "@/features/children";
+import { VertretungRequestsFacade } from "@/features/vertretung-requests";
 import { getAssignedChildrenForUser } from "@/use-cases/get-assigned-children";
 
 export default async function LandingPage() {
@@ -42,6 +43,7 @@ export default async function LandingPage() {
     childAbsences,
     assignmentsByWeekday,
     vertretungenAsSubstitute,
+    pendingVertretungRequests,
   ] = await Promise.all([
     TimesheetFacade.getEventsInRange(user.id, rangeStart, rangeEnd),
     TimesheetFacade.getSchedulesForChildren(childIds),
@@ -58,6 +60,7 @@ export default async function LandingPage() {
       rangeStart,
       rangeEnd,
     ),
+    VertretungRequestsFacade.listForUser(user.id, rangeStart, rangeEnd),
   ]);
 
   return (
@@ -84,6 +87,14 @@ export default async function LandingPage() {
         childName: `${v.child.firstName} ${v.child.lastName}`,
         startTime: v.startTime,
         endTime: v.endTime,
+      }))}
+      pendingVertretungRequests={pendingVertretungRequests.map((r) => ({
+        id: r.id,
+        date: r.date.toISOString().slice(0, 10),
+        childNameText: r.childNameText,
+        startTime: r.startTime,
+        endTime: r.endTime,
+        status: r.status as "PENDING" | "RESOLVED",
       }))}
     />
   );

--- a/src/features/children/actions.ts
+++ b/src/features/children/actions.ts
@@ -19,7 +19,7 @@ const ROUTE = "/admin/children";
 
 // Search children assigned to the current Schulbegleiter. Lives in the
 // children feature because it queries child data; the timesheet entry form
-// calls it to pick a child for Einspringen/indirect work.
+// calls it to pick a child for indirect work.
 export async function searchAssignedChildrenAction(query: string) {
   const { id: userId } = await requireAuth();
   return ChildrenFacade.searchAssignedChildren(userId, query);
@@ -124,7 +124,6 @@ export async function listWorkEventsForChildAction(childId: string) {
     endTime: e.endTime,
     note: e.note,
     type: e.type,
-    isSubstitute: e.isSubstitute,
     userName: e.user.name,
     userId: e.userId,
     deleted: e.deleted,

--- a/src/features/children/components/calendar/event-block.tsx
+++ b/src/features/children/components/calendar/event-block.tsx
@@ -65,11 +65,6 @@ export function EventBlock({ ev, col, cols, onDelete, onMove }: Props) {
   } else if (ev.layer === "event") {
     layerClasses = match(ev.eventKind)
       .with(
-        "substitute",
-        () =>
-          "z-30 bg-red-500/20 border border-red-500/60 text-red-900 ring-1 ring-red-500 dark:text-red-200",
-      )
-      .with(
         "indirect",
         () =>
           "z-30 bg-amber-500/20 border border-amber-500/60 text-amber-900 dark:text-amber-200",

--- a/src/features/children/components/calendar/week-calendar.tsx
+++ b/src/features/children/components/calendar/week-calendar.tsx
@@ -423,6 +423,35 @@ export function KinderWeekCalendar({
                     ),
                   )}
 
+                  {dayStacked.length === 0 &&
+                    dayEinsaetze.map((e) => {
+                      if (!e.startTime || !e.endTime) return null;
+                      const startHour = clampHours(parseTime(e.startTime));
+                      const endHour = clampHours(parseTime(e.endTime));
+                      const top = (startHour - START_HOUR) * HOUR_HEIGHT;
+                      const height = Math.max(
+                        20,
+                        (endHour - startHour) * HOUR_HEIGHT,
+                      );
+                      return (
+                        <div
+                          key={e.id}
+                          className="absolute inset-x-1 z-10 flex flex-col gap-0.5 overflow-hidden rounded border border-amber-500/40 bg-amber-500/15 px-1.5 py-1 text-[11px] leading-tight text-amber-900"
+                          style={{ top, height }}
+                        >
+                          <span className="text-[9px] font-semibold uppercase tracking-wide opacity-50">
+                            Einsatz
+                          </span>
+                          <div className="truncate font-medium">
+                            {e.userName}
+                          </div>
+                          <span className="font-semibold">
+                            {e.startTime}–{e.endTime}
+                          </span>
+                        </div>
+                      );
+                    })}
+
                   {dragSelection && dragSelection.weekday === weekday ? (
                     <Popover
                       open={createOpen}

--- a/src/features/children/components/calendar/week-calendar.tsx
+++ b/src/features/children/components/calendar/week-calendar.tsx
@@ -417,6 +417,33 @@ export function KinderWeekCalendar({
                   ),
                 )}
 
+                {dayStacked.length === 0 &&
+                  dayEinsaetze.map((e) => {
+                    if (!e.startTime || !e.endTime) return null;
+                    const startHour = clampHours(parseTime(e.startTime));
+                    const endHour = clampHours(parseTime(e.endTime));
+                    const top = (startHour - START_HOUR) * HOUR_HEIGHT;
+                    const height = Math.max(
+                      20,
+                      (endHour - startHour) * HOUR_HEIGHT,
+                    );
+                    return (
+                      <div
+                        key={e.id}
+                        className="absolute inset-x-1 z-10 flex flex-col gap-0.5 overflow-hidden rounded border border-amber-500/40 bg-amber-500/15 px-1.5 py-1 text-[11px] leading-tight text-amber-900"
+                        style={{ top, height }}
+                      >
+                        <span className="text-[9px] font-semibold uppercase tracking-wide opacity-50">
+                          Einsatz
+                        </span>
+                        <div className="truncate font-medium">{e.userName}</div>
+                        <span className="font-semibold">
+                          {e.startTime}–{e.endTime}
+                        </span>
+                      </div>
+                    );
+                  })}
+
                 {dragSelection && dragSelection.weekday === weekday ? (
                   <Popover
                     open={createOpen}

--- a/src/features/children/components/calendar/week-utils.ts
+++ b/src/features/children/components/calendar/week-utils.ts
@@ -53,7 +53,7 @@ export function clampHours(h: number): number {
 }
 
 export type EventLayer = "schedule" | "assignment" | "absence" | "event";
-export type EventKind = "work" | "substitute" | "indirect";
+export type EventKind = "work" | "indirect";
 
 export type CalendarEvent = {
   layer: EventLayer;
@@ -70,8 +70,8 @@ export type CalendarEvent = {
   sublabel?: string;
   // Assignment-only
   tandem?: boolean;
-  // Event-only: distinguishes regular work, substitute (Einspringen) and
-  // indirect (Lehrergespräch/Workshop) entries so EventBlock can color them.
+  // Event-only: distinguishes regular work from indirect
+  // (Lehrergespräch/Workshop) entries so EventBlock can color them.
   eventKind?: EventKind;
 };
 

--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -113,7 +113,7 @@ export const ChildrenFacade = {
   },
 
   // Search children currently assigned to a given Schulbegleiter (used by the
-  // timesheet entry form to pick a child for Einspringen/indirect work).
+  // timesheet entry form to pick a child for indirect work).
   async searchAssignedChildren(userId: string, query: string) {
     return searchAssignedChildrenByName(userId, query);
   },

--- a/src/features/children/services/events.ts
+++ b/src/features/children/services/events.ts
@@ -75,14 +75,9 @@ export async function updateWorkEventAsAdmin(
 export async function deleteWorkEventAsAdmin(id: string) {
   const existing = await prisma.event.findUniqueOrThrow({ where: { id } });
   if (existing.signatureKey) {
-    return prisma.event.update({
-      where: { id },
-      data: { deleted: true },
-    });
+    await prisma.event.update({ where: { id }, data: { deleted: true } });
   } else {
-    return prisma.event.delete({
-      where: { id },
-    });
+    await prisma.event.delete({ where: { id } });
   }
 }
 
@@ -99,7 +94,12 @@ export async function listWorkEventsForChildInRange(
   to: Date,
 ): Promise<ChildWorkEvent[]> {
   return prisma.event.findMany({
-    where: { childId, type: EventType.WORK, date: { gte: from, lte: to } },
+    where: {
+      childId,
+      type: EventType.WORK,
+      deleted: false,
+      date: { gte: from, lte: to },
+    },
     include: { user: true },
     orderBy: { date: "asc" },
   });

--- a/src/features/children/services/fuzzy-match.ts
+++ b/src/features/children/services/fuzzy-match.ts
@@ -1,0 +1,88 @@
+import { prisma } from "@/lib/prisma";
+
+// Jaro-Winkler similarity — returns 0.0 (no match) to 1.0 (identical).
+function jaroWinkler(a: string, b: string): number {
+  if (a === b) return 1;
+  const la = a.length;
+  const lb = b.length;
+  if (la === 0 || lb === 0) return 0;
+
+  const matchDistance = Math.floor(Math.max(la, lb) / 2) - 1;
+  const aMatches = new Array<boolean>(la).fill(false);
+  const bMatches = new Array<boolean>(lb).fill(false);
+
+  let matches = 0;
+  let transpositions = 0;
+
+  for (let i = 0; i < la; i++) {
+    const start = Math.max(0, i - matchDistance);
+    const end = Math.min(i + matchDistance + 1, lb);
+    for (let j = start; j < end; j++) {
+      if (bMatches[j] || a[i] !== b[j]) continue;
+      aMatches[i] = true;
+      bMatches[j] = true;
+      matches++;
+      break;
+    }
+  }
+
+  if (matches === 0) return 0;
+
+  let k = 0;
+  for (let i = 0; i < la; i++) {
+    if (!aMatches[i]) continue;
+    while (!bMatches[k]) k++;
+    if (a[i] !== b[k]) transpositions++;
+    k++;
+  }
+
+  const jaro =
+    (matches / la + matches / lb + (matches - transpositions / 2) / matches) /
+    3;
+
+  // Winkler boost: reward common prefix (up to 4 chars)
+  let prefix = 0;
+  for (let i = 0; i < Math.min(4, Math.min(la, lb)); i++) {
+    if (a[i] !== b[i]) break;
+    prefix++;
+  }
+
+  return jaro + prefix * 0.1 * (1 - jaro);
+}
+
+function normalize(s: string): string {
+  return s.toLowerCase().trim().replace(/\s+/g, " ");
+}
+
+export type MatchResult = {
+  childId: string;
+  confidence: number;
+};
+
+export const MATCH_AUTO_THRESHOLD = 0.85;
+
+export async function fuzzyMatchChild(
+  nameText: string,
+): Promise<MatchResult | null> {
+  const children = await prisma.child.findMany({
+    select: { id: true, firstName: true, lastName: true },
+  });
+
+  const query = normalize(nameText);
+  let best: MatchResult | null = null;
+
+  for (const child of children) {
+    const full = normalize(`${child.firstName} ${child.lastName}`);
+    const reversed = normalize(`${child.lastName} ${child.firstName}`);
+    const score = Math.max(
+      jaroWinkler(query, full),
+      jaroWinkler(query, reversed),
+    );
+
+    if (best === null || score > best.confidence) {
+      best = { childId: child.id, confidence: score };
+    }
+  }
+
+  return best;
+}

--- a/src/features/children/services/fuzzy-match.ts
+++ b/src/features/children/services/fuzzy-match.ts
@@ -1,88 +1,28 @@
 import { prisma } from "@/lib/prisma";
 
-// Jaro-Winkler similarity — returns 0.0 (no match) to 1.0 (identical).
-function jaroWinkler(a: string, b: string): number {
-  if (a === b) return 1;
-  const la = a.length;
-  const lb = b.length;
-  if (la === 0 || lb === 0) return 0;
-
-  const matchDistance = Math.floor(Math.max(la, lb) / 2) - 1;
-  const aMatches = new Array<boolean>(la).fill(false);
-  const bMatches = new Array<boolean>(lb).fill(false);
-
-  let matches = 0;
-  let transpositions = 0;
-
-  for (let i = 0; i < la; i++) {
-    const start = Math.max(0, i - matchDistance);
-    const end = Math.min(i + matchDistance + 1, lb);
-    for (let j = start; j < end; j++) {
-      if (bMatches[j] || a[i] !== b[j]) continue;
-      aMatches[i] = true;
-      bMatches[j] = true;
-      matches++;
-      break;
-    }
-  }
-
-  if (matches === 0) return 0;
-
-  let k = 0;
-  for (let i = 0; i < la; i++) {
-    if (!aMatches[i]) continue;
-    while (!bMatches[k]) k++;
-    if (a[i] !== b[k]) transpositions++;
-    k++;
-  }
-
-  const jaro =
-    (matches / la + matches / lb + (matches - transpositions / 2) / matches) /
-    3;
-
-  // Winkler boost: reward common prefix (up to 4 chars)
-  let prefix = 0;
-  for (let i = 0; i < Math.min(4, Math.min(la, lb)); i++) {
-    if (a[i] !== b[i]) break;
-    prefix++;
-  }
-
-  return jaro + prefix * 0.1 * (1 - jaro);
-}
+export type MatchResult = {
+  childId: string;
+};
 
 function normalize(s: string): string {
   return s.toLowerCase().trim().replace(/\s+/g, " ");
 }
 
-export type MatchResult = {
-  childId: string;
-  confidence: number;
-};
-
-export const MATCH_AUTO_THRESHOLD = 0.85;
-
-export async function fuzzyMatchChild(
+export async function exactMatchChild(
   nameText: string,
 ): Promise<MatchResult | null> {
+  const query = normalize(nameText);
   const children = await prisma.child.findMany({
     select: { id: true, firstName: true, lastName: true },
   });
 
-  const query = normalize(nameText);
-  let best: MatchResult | null = null;
-
   for (const child of children) {
     const full = normalize(`${child.firstName} ${child.lastName}`);
     const reversed = normalize(`${child.lastName} ${child.firstName}`);
-    const score = Math.max(
-      jaroWinkler(query, full),
-      jaroWinkler(query, reversed),
-    );
-
-    if (best === null || score > best.confidence) {
-      best = { childId: child.id, confidence: score };
+    if (query === full || query === reversed) {
+      return { childId: child.id };
     }
   }
 
-  return best;
+  return null;
 }

--- a/src/features/timesheet/actions.ts
+++ b/src/features/timesheet/actions.ts
@@ -4,9 +4,11 @@ import { revalidatePath } from "next/cache";
 import { requireAuth } from "@/lib/auth-guards";
 import { TimesheetFacade } from "./facade";
 import { createTimesheetEvent } from "@/use-cases/create-timesheet-event";
+import { createIndirectEventByName } from "@/use-cases/create-indirect-event-by-name";
 import type {
   ConfirmWorkEventsInput,
   CreateEventInput,
+  CreateIndirectByNameInput,
   SubmitMonthlyReportInput,
   UpdateEventInput,
 } from "./schemas";
@@ -14,6 +16,15 @@ import type {
 export async function createEventAction(input: CreateEventInput) {
   const { id: userId } = await requireAuth();
   const result = await createTimesheetEvent(userId, input);
+  revalidatePath("/");
+  return result;
+}
+
+export async function createIndirectEventByNameAction(
+  input: CreateIndirectByNameInput,
+) {
+  const { id: userId } = await requireAuth();
+  const result = await createIndirectEventByName(userId, input);
   revalidatePath("/");
   return result;
 }

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -36,7 +36,7 @@ import { cn, formatIsoDateUtc } from "@/lib/utils";
 import type { VertretungDay } from "./timesheet-shell";
 
 type EventLike = Pick<Event, "id" | "type" | "date" | "childId">;
-type WorkVariant = "OWN" | "SUBSTITUTE" | "INDIRECT";
+type WorkVariant = "OWN" | "INDIRECT";
 
 function isWeekend(iso: string) {
   const d = parseIsoDate(iso);
@@ -205,10 +205,6 @@ export function NewEntrySheet({
       if (dateIsWeekend) return false;
       return childIds.length >= 1 && Boolean(duration);
     }
-    if (workVariant === "SUBSTITUTE") {
-      if (dateIsWeekend) return false;
-      return Boolean(otherChild) && Boolean(duration);
-    }
     // INDIRECT
     return Boolean(otherChild) && note.trim().length >= 3 && Boolean(duration);
   }, [
@@ -301,7 +297,6 @@ export function NewEntrySheet({
       } else if (workVariant === "OWN") {
         await createEventAction({
           type: EventType.WORK,
-          workVariant: "OWN",
           date,
           childIds,
           startTime,
@@ -314,18 +309,6 @@ export function NewEntrySheet({
             childIds.length === 1 ? "" : "er"
           })`,
         );
-      } else if (workVariant === "SUBSTITUTE") {
-        await createEventAction({
-          type: EventType.WORK,
-          workVariant: "SUBSTITUTE",
-          date,
-          childIds: otherChild ? [otherChild.id] : [],
-          startTime,
-          endTime,
-          note: note.trim() || undefined,
-          signaturePngBase64: pngBase64,
-        });
-        toast.success("Einspringen gespeichert");
       } else {
         await createEventAction({
           type: EventType.INDIRECT,
@@ -545,7 +528,7 @@ export function NewEntrySheet({
 
             {type === EventType.WORK && (
               <>
-                <div className="grid grid-cols-3 gap-1.5">
+                <div className="grid grid-cols-2 gap-1.5">
                   <Button
                     type="button"
                     variant={workVariant === "OWN" ? "default" : "outline"}
@@ -553,16 +536,6 @@ export function NewEntrySheet({
                     className="h-10 text-xs sm:text-sm"
                   >
                     <Briefcase className="size-3.5" /> Eigenes Kind
-                  </Button>
-                  <Button
-                    type="button"
-                    variant={
-                      workVariant === "SUBSTITUTE" ? "default" : "outline"
-                    }
-                    onClick={() => setWorkVariant("SUBSTITUTE")}
-                    className="h-10 text-xs sm:text-sm"
-                  >
-                    <UserPlus className="size-3.5" /> Einspringen
                   </Button>
                   <Button
                     type="button"
@@ -615,21 +588,6 @@ export function NewEntrySheet({
                     </div>
                   ))}
 
-                {workVariant === "SUBSTITUTE" && (
-                  <div className="space-y-1.5">
-                    <Label htmlFor="other-child">Kind (Einspringen)</Label>
-                    <ChildSearchCombobox
-                      id="other-child"
-                      value={otherChild}
-                      onChange={setOtherChild}
-                      placeholder="Kind suchen…"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Suche nach dem Kind, für das du einspringst.
-                    </p>
-                  </div>
-                )}
-
                 {workVariant === "INDIRECT" && (
                   <div className="space-y-1.5">
                     <Label htmlFor="other-child">Kind</Label>
@@ -645,13 +603,12 @@ export function NewEntrySheet({
                   </div>
                 )}
 
-                {(workVariant === "OWN" || workVariant === "SUBSTITUTE") &&
-                  dateIsWeekend && (
-                    <p className="rounded-lg border border-amber-400/50 bg-amber-50/50 px-3 py-2 text-xs text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
-                      Diese Tätigkeit ist nur an Werktagen möglich. Für
-                      Wochenend-Tätigkeiten bitte &bdquo;Indirekt&ldquo; wählen.
-                    </p>
-                  )}
+                {workVariant === "OWN" && dateIsWeekend && (
+                  <p className="rounded-lg border border-amber-400/50 bg-amber-50/50 px-3 py-2 text-xs text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                    Diese Tätigkeit ist nur an Werktagen möglich. Für
+                    Wochenend-Tätigkeiten bitte &bdquo;Indirekt&ldquo; wählen.
+                  </p>
+                )}
 
                 <div className="grid grid-cols-[1fr_auto_1fr] gap-2 items-end">
                   <div className="space-y-1.5">
@@ -771,10 +728,6 @@ export function NewEntrySheet({
                 .with(
                   { workVariant: "INDIRECT" },
                   () => "Indirekte Leistung bestätigen",
-                )
-                .with(
-                  { workVariant: "SUBSTITUTE" },
-                  () => "Einspringen bestätigen",
                 )
                 .otherwise(() => "Arbeitszeit bestätigen")
         }

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Briefcase, Stethoscope, UserCheck } from "lucide-react";
+import { Briefcase, Stethoscope, UserCheck, UserPlus } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { EventType, type Schedule } from "@/generated/prisma";
 import { SignaturePadDialog } from "./signature-pad-dialog";
 import { createEventAction } from "../actions";
+import { createVertretungRequestAction } from "@/features/vertretung-requests/actions";
 import {
   formatDuration,
   parseIsoDate,
@@ -75,11 +76,12 @@ export function NewEntrySheet({
   lastEntry,
   substituteOn = [],
 }: Props) {
-  const [type, setType] = useState<EventType>(EventType.WORK);
+  const [type, setType] = useState<EventType | "VERTRETUNG">(EventType.WORK);
   const [date, setDate] = useState(formatIsoDateUtc(defaultDate));
   const [startTime, setStartTime] = useState("08:00");
   const [endTime, setEndTime] = useState("17:00");
   const [note, setNote] = useState("");
+  const [vertretungChildName, setVertretungChildName] = useState("");
 
   // Vertretungen for the currently selected date
   const dayVertretungen = useMemo(
@@ -112,6 +114,7 @@ export function NewEntrySheet({
       setStartTime("08:00");
       setEndTime("17:00");
       setNote("");
+      setVertretungChildName("");
     }
   }, [open, defaultDate]);
 
@@ -136,7 +139,11 @@ export function NewEntrySheet({
   }, [startTime, endTime]);
 
   const canProceed =
-    type === EventType.SICK ? true : childIds.length >= 1 && Boolean(duration);
+    type === "VERTRETUNG"
+      ? vertretungChildName.trim().length >= 2 && Boolean(duration)
+      : type === EventType.SICK
+        ? true
+        : childIds.length >= 1 && Boolean(duration);
 
   const toggleChild = (id: string) => {
     setChildIds((cur) =>
@@ -213,22 +220,33 @@ export function NewEntrySheet({
   const submitWithSignature = async (pngBase64: string) => {
     setSubmitting(true);
     try {
-      await createEventAction({
-        type,
-        date,
-        childIds: type === EventType.WORK ? childIds : [],
-        startTime: type === EventType.WORK ? startTime : undefined,
-        endTime: type === EventType.WORK ? endTime : undefined,
-        note: note.trim() || undefined,
-        signaturePngBase64: pngBase64,
-      });
-      toast.success(
-        type === EventType.WORK
-          ? `Eintrag gespeichert (${childIds.length} Kind${
-              childIds.length === 1 ? "" : "er"
-            })`
-          : "Krankheit gespeichert",
-      );
+      if (type === "VERTRETUNG") {
+        await createVertretungRequestAction({
+          childNameText: vertretungChildName.trim(),
+          date,
+          startTime,
+          endTime,
+          signaturePngBase64: pngBase64,
+        });
+        toast.success("Vertretungs-Antrag eingereicht.");
+      } else {
+        await createEventAction({
+          type,
+          date,
+          childIds: type === EventType.WORK ? childIds : [],
+          startTime: type === EventType.WORK ? startTime : undefined,
+          endTime: type === EventType.WORK ? endTime : undefined,
+          note: note.trim() || undefined,
+          signaturePngBase64: pngBase64,
+        });
+        toast.success(
+          type === EventType.WORK
+            ? `Eintrag gespeichert (${childIds.length} Kind${
+                childIds.length === 1 ? "" : "er"
+              })`
+            : "Krankheit gespeichert",
+        );
+      }
       setSigOpen(false);
       onOpenChange(false);
     } catch (e: unknown) {
@@ -239,9 +257,11 @@ export function NewEntrySheet({
   };
 
   const signerSubtitle =
-    type === EventType.WORK
-      ? `${date} · ${startTime}–${endTime}${duration ? ` · ${duration}` : ""}`
-      : `${date} · Krank · ganztägig`;
+    type === "VERTRETUNG"
+      ? `${date} · Vertretung · ${startTime}–${endTime}`
+      : type === EventType.WORK
+        ? `${date} · ${startTime}–${endTime}${duration ? ` · ${duration}` : ""}`
+        : `${date} · Krank · ganztägig`;
 
   return (
     <>
@@ -279,7 +299,7 @@ export function NewEntrySheet({
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-3 gap-2">
               <Button
                 type="button"
                 variant={type === EventType.WORK ? "default" : "outline"}
@@ -300,7 +320,70 @@ export function NewEntrySheet({
               >
                 <Stethoscope className="size-4" /> Krank
               </Button>
+              <Button
+                type="button"
+                variant={type === "VERTRETUNG" ? "default" : "outline"}
+                onClick={() => setType("VERTRETUNG")}
+                className={cn(
+                  "h-12",
+                  type === "VERTRETUNG" &&
+                    "bg-amber-600 hover:bg-amber-700 text-white",
+                )}
+              >
+                <UserPlus className="size-4" /> Vertretung
+              </Button>
             </div>
+
+            {type === "VERTRETUNG" && (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="vertretung-child">Name des Kindes</Label>
+                  <Input
+                    id="vertretung-child"
+                    value={vertretungChildName}
+                    onChange={(e) => setVertretungChildName(e.target.value)}
+                    placeholder="Vor- und Nachname"
+                    autoComplete="off"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Bitte den Namen so genau wie möglich eingeben.
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto_1fr] gap-2 items-end">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="v-start">Start</Label>
+                    <Input
+                      id="v-start"
+                      type="time"
+                      value={startTime}
+                      onChange={(e) => setStartTime(e.target.value)}
+                      className="h-14 text-xl font-mono tabular-nums"
+                    />
+                  </div>
+                  <span className="pb-3 text-muted-foreground">→</span>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="v-end">Ende</Label>
+                    <Input
+                      id="v-end"
+                      type="time"
+                      value={endTime}
+                      onChange={(e) => setEndTime(e.target.value)}
+                      className="h-14 text-xl font-mono tabular-nums"
+                    />
+                  </div>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {duration
+                    ? `Dauer: ${duration}`
+                    : "Ende muss nach Start liegen"}
+                </p>
+
+                <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                  Der Antrag wird einem Admin zur Zuordnung weitergeleitet.
+                </div>
+              </>
+            )}
 
             {type === EventType.WORK && (
               <>
@@ -454,9 +537,11 @@ export function NewEntrySheet({
         open={sigOpen}
         onOpenChange={setSigOpen}
         title={
-          type === EventType.WORK
-            ? "Arbeitszeit bestätigen"
-            : "Krankheit bestätigen"
+          type === "VERTRETUNG"
+            ? "Vertretung bestätigen"
+            : type === EventType.WORK
+              ? "Arbeitszeit bestätigen"
+              : "Krankheit bestätigen"
         }
         subtitle={signerSubtitle}
         signerLabel={`${currentUserName} (Mitarbeiter)`}

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -18,11 +18,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import { EventType, type Event, type Schedule } from "@/generated/prisma";
 import { SignaturePadDialog } from "./signature-pad-dialog";
-import {
-  ChildSearchCombobox,
-  type ChildOption as SearchChildOption,
-} from "./child-search-combobox";
-import { createEventAction } from "../actions";
+import { createEventAction, createIndirectEventByNameAction } from "../actions";
 import { createVertretungRequestAction } from "@/features/vertretung-requests/actions";
 import {
   formatDuration,
@@ -36,25 +32,13 @@ import { cn, formatIsoDateUtc } from "@/lib/utils";
 import type { VertretungDay } from "./timesheet-shell";
 
 type EventLike = Pick<Event, "id" | "type" | "date" | "childId">;
-type WorkVariant = "OWN" | "INDIRECT";
+type WorkVariant = "OWN" | "VERTRETUNG" | "INDIRECT";
 
 function isWeekend(iso: string) {
   const d = parseIsoDate(iso);
   const dow = d.getDay();
   return dow === 0 || dow === 6;
 }
-
-type LastEntry = {
-  startTime: string | null;
-  endTime: string | null;
-};
-
-type QuickSlot = {
-  key: string;
-  label: string;
-  start: string;
-  end: string;
-};
 
 type Props = {
   open: boolean;
@@ -64,22 +48,11 @@ type Props = {
   assignmentsByWeekday: AssignmentsByWeekday;
   currentUserName: string;
   schedules: Schedule[];
-  lastEntry: LastEntry | null;
   /** Vertretung days for the current user — listed in the Vertretung tab. */
   substituteOn?: VertretungDay[];
   /** Existing events — used to hide Vertretungen that already have an Eintrag. */
   events?: EventLike[];
 };
-
-function addMinutes(time: string, minutes: number): string {
-  const total = Math.max(
-    0,
-    Math.min(24 * 60 - 1, timeToMinutes(time) + minutes),
-  );
-  const h = Math.floor(total / 60);
-  const m = total % 60;
-  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
-}
 
 export function NewEntrySheet({
   open,
@@ -89,18 +62,17 @@ export function NewEntrySheet({
   assignmentsByWeekday,
   currentUserName,
   schedules,
-  lastEntry,
   substituteOn = [],
   events = [],
 }: Props) {
-  const [type, setType] = useState<EventType | "VERTRETUNG">(EventType.WORK);
+  const [type, setType] = useState<EventType>(EventType.WORK);
   const [workVariant, setWorkVariant] = useState<WorkVariant>("OWN");
   const [date, setDate] = useState(formatIsoDateUtc(defaultDate));
   const [startTime, setStartTime] = useState("08:00");
   const [endTime, setEndTime] = useState("17:00");
   const [note, setNote] = useState("");
   const [vertretungChildName, setVertretungChildName] = useState("");
-  const [otherChild, setOtherChild] = useState<SearchChildOption | null>(null);
+  const [indirectChildName, setIndirectChildName] = useState("");
 
   // Child IDs that already have a work Event for this date — used to hide
   // Vertretungen the SB has already submitted an Eintrag for. Filtering by
@@ -170,7 +142,7 @@ export function NewEntrySheet({
       setEndTime("17:00");
       setNote("");
       setVertretungChildName("");
-      setOtherChild(null);
+      setIndirectChildName("");
     }
   }, [open, defaultDate]);
 
@@ -197,16 +169,20 @@ export function NewEntrySheet({
   const dateIsWeekend = isWeekend(date);
 
   const canProceed = useMemo(() => {
-    if (type === "VERTRETUNG") {
+    if (type === EventType.SICK) return true;
+    if (workVariant === "VERTRETUNG") {
       return vertretungChildName.trim().length >= 2 && Boolean(duration);
     }
-    if (type === EventType.SICK) return true;
     if (workVariant === "OWN") {
       if (dateIsWeekend) return false;
       return childIds.length >= 1 && Boolean(duration);
     }
     // INDIRECT
-    return Boolean(otherChild) && note.trim().length >= 3 && Boolean(duration);
+    return (
+      indirectChildName.trim().length >= 2 &&
+      note.trim().length >= 3 &&
+      Boolean(duration)
+    );
   }, [
     type,
     workVariant,
@@ -214,7 +190,7 @@ export function NewEntrySheet({
     dateIsWeekend,
     childIds.length,
     duration,
-    otherChild,
+    indirectChildName,
     note,
   ]);
 
@@ -224,59 +200,43 @@ export function NewEntrySheet({
     );
   };
 
-  const quickSlots = useMemo<QuickSlot[]>(() => {
-    const out: QuickSlot[] = [];
-    const seen = new Set<string>();
-    const push = (slot: QuickSlot) => {
-      const fp = `${slot.start}-${slot.end}`;
-      if (seen.has(fp)) return;
-      seen.add(fp);
-      out.push(slot);
-    };
-
+  // Times derived from the Schulbegleiter's assigned child(ren) Stundenplan for
+  // the chosen weekday. Earliest start + latest end across the relevant
+  // schedules. Null when no schedule covers the day — the SB then enters
+  // start/end manually.
+  const dayScheduleTimes = useMemo<{
+    start: string;
+    end: string;
+  } | null>(() => {
     const wd = weekdayIndex(parseIsoDate(date));
     const relevantChildIds =
       childIds.length > 0 ? childIds : dayAssignedChildren.map((c) => c.id);
     const daySchedules = schedules.filter(
       (s) => s.weekday === wd && relevantChildIds.includes(s.childId),
     );
-    if (daySchedules.length > 0) {
-      const start = daySchedules.reduce((acc, s) =>
-        timeToMinutes(s.startTime) < timeToMinutes(acc.startTime) ? s : acc,
-      ).startTime;
-      const end = daySchedules.reduce((acc, s) =>
-        timeToMinutes(s.endTime) > timeToMinutes(acc.endTime) ? s : acc,
-      ).endTime;
-      push({
-        key: "schedule",
-        label: "Stundenplan",
-        start,
-        end,
-      });
-    }
+    if (daySchedules.length === 0) return null;
+    const start = daySchedules.reduce((acc, s) =>
+      timeToMinutes(s.startTime) < timeToMinutes(acc.startTime) ? s : acc,
+    ).startTime;
+    const end = daySchedules.reduce((acc, s) =>
+      timeToMinutes(s.endTime) > timeToMinutes(acc.endTime) ? s : acc,
+    ).endTime;
+    return { start, end };
+  }, [date, schedules, dayAssignedChildren, childIds]);
 
-    if (lastEntry?.startTime && lastEntry?.endTime) {
-      push({
-        key: "last",
-        label: "Letzter Eintrag",
-        start: lastEntry.startTime,
-        end: lastEntry.endTime,
-      });
-      push({
-        key: "last-plus-15",
-        label: "Letzter +15m",
-        start: lastEntry.startTime,
-        end: addMinutes(lastEntry.endTime, 15),
-      });
-    }
-
-    return out;
-  }, [date, schedules, dayAssignedChildren, childIds, lastEntry]);
+  // Auto-fill Start/End from the Stundenplan when entering Arbeit/Eigenes Kind.
+  // The SB can still edit the times manually after the fill.
+  useEffect(() => {
+    if (type !== EventType.WORK || workVariant !== "OWN") return;
+    if (!dayScheduleTimes) return;
+    setStartTime(dayScheduleTimes.start);
+    setEndTime(dayScheduleTimes.end);
+  }, [type, workVariant, dayScheduleTimes]);
 
   const submitWithSignature = async (pngBase64: string) => {
     setSubmitting(true);
     try {
-      if (type === "VERTRETUNG") {
+      if (type === EventType.WORK && workVariant === "VERTRETUNG") {
         await createVertretungRequestAction({
           childNameText: vertretungChildName.trim(),
           date,
@@ -310,10 +270,9 @@ export function NewEntrySheet({
           })`,
         );
       } else {
-        await createEventAction({
-          type: EventType.INDIRECT,
+        await createIndirectEventByNameAction({
+          childNameText: indirectChildName.trim(),
           date,
-          childIds: otherChild ? [otherChild.id] : [],
           startTime,
           endTime,
           note: note.trim(),
@@ -331,7 +290,7 @@ export function NewEntrySheet({
   };
 
   const signerSubtitle =
-    type === "VERTRETUNG"
+    type === EventType.WORK && workVariant === "VERTRETUNG"
       ? `${date} · Vertretung · ${startTime}–${endTime}${
           duration ? ` · ${duration}` : ""
         }`
@@ -375,7 +334,7 @@ export function NewEntrySheet({
               />
             </div>
 
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-2 gap-2">
               <Button
                 type="button"
                 variant={type === EventType.WORK ? "default" : "outline"}
@@ -396,146 +355,32 @@ export function NewEntrySheet({
               >
                 <Stethoscope className="size-4" /> Krank
               </Button>
-              <Button
-                type="button"
-                variant={type === "VERTRETUNG" ? "default" : "outline"}
-                onClick={() => setType("VERTRETUNG")}
-                className={cn(
-                  "h-12",
-                  type === "VERTRETUNG" &&
-                    "bg-amber-600 hover:bg-amber-700 text-white",
-                )}
-              >
-                <UserPlus className="size-4" /> Vertretung
-              </Button>
             </div>
-
-            {type === "VERTRETUNG" && (
-              <>
-                <div className="space-y-1.5">
-                  <Label htmlFor="vertretung-child">Name des Kindes</Label>
-                  <Input
-                    id="vertretung-child"
-                    value={vertretungChildName}
-                    onChange={(e) => setVertretungChildName(e.target.value)}
-                    placeholder="Vor- und Nachname"
-                    autoComplete="off"
-                  />
-                </div>
-
-                <div className="grid grid-cols-[1fr_auto_1fr] gap-2 items-end">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="v-start">Start</Label>
-                    <Input
-                      id="v-start"
-                      type="time"
-                      value={startTime}
-                      onChange={(e) => setStartTime(e.target.value)}
-                      className="h-14 text-xl font-mono tabular-nums"
-                    />
-                  </div>
-                  <span className="pb-3 text-muted-foreground">→</span>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="v-end">Ende</Label>
-                    <Input
-                      id="v-end"
-                      type="time"
-                      value={endTime}
-                      onChange={(e) => setEndTime(e.target.value)}
-                      className="h-14 text-xl font-mono tabular-nums"
-                    />
-                  </div>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {duration
-                    ? `Dauer: ${duration}`
-                    : "Ende muss nach Start liegen"}
-                </p>
-
-                {availableVertretungen.length > 0 && (
-                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
-                    {availableVertretungen.flatMap((v) =>
-                      v.timeBlocks.map((b, i) => {
-                        const active =
-                          vertretungChildName === v.childName &&
-                          startTime === b.startTime &&
-                          endTime === b.endTime;
-                        return (
-                          <button
-                            key={`${v.childId}-${i}`}
-                            type="button"
-                            onClick={() => {
-                              setVertretungChildName(v.childName);
-                              setStartTime(b.startTime);
-                              setEndTime(b.endTime);
-                            }}
-                            className={cn(
-                              "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors",
-                              active
-                                ? "border-amber-400 bg-amber-400/10 text-foreground"
-                                : "border-border bg-muted/40 hover:bg-accent",
-                            )}
-                          >
-                            <div className="flex flex-col">
-                              <span className="text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
-                                Vertretung
-                              </span>
-                              <span className="font-medium">{v.childName}</span>
-                            </div>
-                            <span className="font-mono tabular-nums text-muted-foreground">
-                              {b.startTime}–{b.endTime}
-                            </span>
-                          </button>
-                        );
-                      }),
-                    )}
-                  </div>
-                )}
-
-                {quickSlots.length > 0 && (
-                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-3">
-                    {quickSlots.map((slot) => (
-                      <button
-                        key={slot.key}
-                        type="button"
-                        onClick={() => {
-                          setStartTime(slot.start);
-                          setEndTime(slot.end);
-                        }}
-                        className={cn(
-                          "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors",
-                          startTime === slot.start && endTime === slot.end
-                            ? "border-amber-400 bg-amber-400/10 text-foreground"
-                            : "border-border bg-muted/40 hover:bg-accent",
-                        )}
-                      >
-                        <span className="font-medium">{slot.label}</span>
-                        <span className="font-mono tabular-nums text-muted-foreground">
-                          {slot.start}–{slot.end}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-
-                <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                  Bei exakter Übereinstimmung wird der Eintrag sofort
-                  gespeichert — sonst leiten wir den Antrag an einen Admin
-                  weiter.
-                </div>
-              </>
-            )}
 
             {type === EventType.WORK && (
               <>
-                <div className="grid grid-cols-2 gap-1.5">
+                <div className="grid grid-cols-3 gap-1.5">
                   <Button
                     type="button"
                     variant={workVariant === "OWN" ? "default" : "outline"}
                     onClick={() => setWorkVariant("OWN")}
                     className="h-10 text-xs sm:text-sm"
                   >
-                    <Briefcase className="size-3.5" /> Eigenes Kind
+                    <Briefcase className="size-3.5" /> Direkt
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={
+                      workVariant === "VERTRETUNG" ? "default" : "outline"
+                    }
+                    onClick={() => setWorkVariant("VERTRETUNG")}
+                    className={cn(
+                      "h-10 text-xs sm:text-sm",
+                      workVariant === "VERTRETUNG" &&
+                        "bg-amber-600 hover:bg-amber-700 text-white",
+                    )}
+                  >
+                    <UserPlus className="size-3.5" /> Vertretung
                   </Button>
                   <Button
                     type="button"
@@ -588,14 +433,28 @@ export function NewEntrySheet({
                     </div>
                   ))}
 
+                {workVariant === "VERTRETUNG" && (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="vertretung-child">Name des Kindes</Label>
+                    <Input
+                      id="vertretung-child"
+                      value={vertretungChildName}
+                      onChange={(e) => setVertretungChildName(e.target.value)}
+                      placeholder="Vor- und Nachname"
+                      autoComplete="off"
+                    />
+                  </div>
+                )}
+
                 {workVariant === "INDIRECT" && (
                   <div className="space-y-1.5">
-                    <Label htmlFor="other-child">Kind</Label>
-                    <ChildSearchCombobox
-                      id="other-child"
-                      value={otherChild}
-                      onChange={setOtherChild}
-                      placeholder="Kind suchen…"
+                    <Label htmlFor="indirect-child">Name des Kindes</Label>
+                    <Input
+                      id="indirect-child"
+                      value={indirectChildName}
+                      onChange={(e) => setIndirectChildName(e.target.value)}
+                      placeholder="Vor- und Nachname"
+                      autoComplete="off"
                     />
                     <p className="text-xs text-muted-foreground">
                       Eine indirekte Leistung muss einem Kind zugeordnet werden.
@@ -640,35 +499,61 @@ export function NewEntrySheet({
                     : "Ende muss nach Start liegen"}
                 </p>
 
-                {workVariant === "OWN" && quickSlots.length > 0 && (
-                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-3">
-                    {quickSlots.map((slot) => (
-                      <button
-                        key={slot.key}
-                        type="button"
-                        onClick={() => {
-                          setStartTime(slot.start);
-                          setEndTime(slot.end);
-                        }}
-                        className={cn(
-                          "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors",
-                          startTime === slot.start && endTime === slot.end
-                            ? "border-amber-400 bg-amber-400/10 text-foreground"
-                            : "border-border bg-muted/40 hover:bg-accent",
+                {workVariant === "VERTRETUNG" && (
+                  <>
+                    {availableVertretungen.length > 0 && (
+                      <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
+                        {availableVertretungen.flatMap((v) =>
+                          v.timeBlocks.map((b, i) => {
+                            const active =
+                              vertretungChildName === v.childName &&
+                              startTime === b.startTime &&
+                              endTime === b.endTime;
+                            return (
+                              <button
+                                key={`${v.childId}-${i}`}
+                                type="button"
+                                onClick={() => {
+                                  setVertretungChildName(v.childName);
+                                  setStartTime(b.startTime);
+                                  setEndTime(b.endTime);
+                                }}
+                                className={cn(
+                                  "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors",
+                                  active
+                                    ? "border-amber-400 bg-amber-400/10 text-foreground"
+                                    : "border-border bg-muted/40 hover:bg-accent",
+                                )}
+                              >
+                                <div className="flex flex-col">
+                                  <span className="text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                    Vertretung
+                                  </span>
+                                  <span className="font-medium">
+                                    {v.childName}
+                                  </span>
+                                </div>
+                                <span className="font-mono tabular-nums text-muted-foreground">
+                                  {b.startTime}–{b.endTime}
+                                </span>
+                              </button>
+                            );
+                          }),
                         )}
-                      >
-                        <span className="font-medium">{slot.label}</span>
-                        <span className="font-mono tabular-nums text-muted-foreground">
-                          {slot.start}–{slot.end}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
+                      </div>
+                    )}
+
+                    <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                      Bei exakter Übereinstimmung wird der Eintrag sofort
+                      gespeichert — sonst leiten wir den Antrag an einen Admin
+                      weiter.
+                    </div>
+                  </>
                 )}
               </>
             )}
 
-            {type !== "VERTRETUNG" &&
+            {!(type === EventType.WORK && workVariant === "VERTRETUNG") &&
               (() => {
                 const indirect =
                   type === EventType.WORK && workVariant === "INDIRECT";
@@ -716,21 +601,17 @@ export function NewEntrySheet({
       <SignaturePadDialog
         open={sigOpen}
         onOpenChange={setSigOpen}
-        title={
-          type === "VERTRETUNG"
-            ? "Vertretung bestätigen"
-            : match({ type, workVariant })
-                .with({ type: EventType.SICK }, () => "Krankheit bestätigen")
-                .with(
-                  { type: EventType.INDIRECT },
-                  () => "Indirekte Leistung bestätigen",
-                )
-                .with(
-                  { workVariant: "INDIRECT" },
-                  () => "Indirekte Leistung bestätigen",
-                )
-                .otherwise(() => "Arbeitszeit bestätigen")
-        }
+        title={match({ type, workVariant })
+          .with({ type: EventType.SICK }, () => "Krankheit bestätigen")
+          .with(
+            { type: EventType.WORK, workVariant: "VERTRETUNG" },
+            () => "Vertretung bestätigen",
+          )
+          .with(
+            { type: EventType.WORK, workVariant: "INDIRECT" },
+            () => "Indirekte Leistung bestätigen",
+          )
+          .otherwise(() => "Arbeitszeit bestätigen")}
         subtitle={signerSubtitle}
         signerLabel={`${currentUserName} (Mitarbeiter)`}
         onConfirm={submitWithSignature}

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Briefcase, Stethoscope, UserCheck, UserPlus } from "lucide-react";
+import { Briefcase, Stethoscope, UserPlus } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -15,7 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
-import { EventType, type Schedule } from "@/generated/prisma";
+import { EventType, type Event, type Schedule } from "@/generated/prisma";
 import { SignaturePadDialog } from "./signature-pad-dialog";
 import { createEventAction } from "../actions";
 import { createVertretungRequestAction } from "@/features/vertretung-requests/actions";
@@ -29,6 +29,8 @@ import type { ChildOption } from "./children-filter";
 import { childIdsForDate, type AssignmentsByWeekday } from "../weekday";
 import { cn, formatIsoDateUtc } from "@/lib/utils";
 import type { VertretungDay } from "./timesheet-shell";
+
+type EventLike = Pick<Event, "id" | "type" | "date" | "childId">;
 
 type LastEntry = {
   startTime: string | null;
@@ -51,8 +53,10 @@ type Props = {
   currentUserName: string;
   schedules: Schedule[];
   lastEntry: LastEntry | null;
-  /** Vertretung days for the current user — so substitute children appear in the form. */
+  /** Vertretung days for the current user — listed in the Vertretung tab. */
   substituteOn?: VertretungDay[];
+  /** Existing events — used to hide Vertretungen that already have an Eintrag. */
+  events?: EventLike[];
 };
 
 function addMinutes(time: string, minutes: number): string {
@@ -75,6 +79,7 @@ export function NewEntrySheet({
   schedules,
   lastEntry,
   substituteOn = [],
+  events = [],
 }: Props) {
   const [type, setType] = useState<EventType | "VERTRETUNG">(EventType.WORK);
   const [date, setDate] = useState(formatIsoDateUtc(defaultDate));
@@ -83,23 +88,58 @@ export function NewEntrySheet({
   const [note, setNote] = useState("");
   const [vertretungChildName, setVertretungChildName] = useState("");
 
-  // Vertretungen for the currently selected date
-  const dayVertretungen = useMemo(
-    () => substituteOn.filter((v) => v.date === date),
-    [substituteOn, date],
-  );
+  // Child IDs that already have a work Event for this date — used to hide
+  // Vertretungen the SB has already submitted an Eintrag for. Filtering by
+  // childId is correct because one Event represents one Vertretung (regardless
+  // of how many time blocks the ChildVertretung was split into).
+  const usedChildIdsForDate = useMemo(() => {
+    const out = new Set<string>();
+    for (const e of events) {
+      if (e.type !== "WORK" || !e.childId) continue;
+      if (formatIsoDateUtc(e.date) === date) out.add(e.childId);
+    }
+    return out;
+  }, [events, date]);
 
+  // Regular weekday-based assignments (Vertretungen live on the Vertretung tab now)
   const dayAssignedChildren = useMemo(() => {
-    // Regular weekday-based assignments
     const regularIds = new Set(
       childIdsForDate(assignmentsByWeekday, parseIsoDate(date)),
     );
-    // Date-specific Vertretung children
-    for (const v of dayVertretungen) regularIds.add(v.childId);
-
     if (regularIds.size === 0) return [] as ChildOption[];
     return assignedChildren.filter((c) => regularIds.has(c.id));
-  }, [date, assignmentsByWeekday, assignedChildren, dayVertretungen]);
+  }, [date, assignmentsByWeekday, assignedChildren]);
+
+  // Vertretungen for the day, grouped by child, excluding ones already used
+  const availableVertretungen = useMemo(() => {
+    const blocks = substituteOn.filter(
+      (v) => v.date === date && !usedChildIdsForDate.has(v.childId),
+    );
+    const map = new Map<
+      string,
+      {
+        childId: string;
+        childName: string;
+        timeBlocks: { startTime: string; endTime: string }[];
+      }
+    >();
+    for (const v of blocks) {
+      if (!map.has(v.childId)) {
+        map.set(v.childId, {
+          childId: v.childId,
+          childName: v.childName,
+          timeBlocks: [],
+        });
+      }
+      map
+        .get(v.childId)!
+        .timeBlocks.push({ startTime: v.startTime, endTime: v.endTime });
+    }
+    for (const entry of map.values()) {
+      entry.timeBlocks.sort((a, b) => a.startTime.localeCompare(b.startTime));
+    }
+    return Array.from(map.values());
+  }, [substituteOn, date, usedChildIdsForDate]);
 
   const [childIds, setChildIds] = useState<string[]>(
     dayAssignedChildren.length === 1 ? [dayAssignedChildren[0].id] : [],
@@ -161,16 +201,6 @@ export function NewEntrySheet({
       out.push(slot);
     };
 
-    // Vertretung time slot(s) — shown first so the substitute can quickly confirm
-    for (const v of dayVertretungen) {
-      push({
-        key: `vertretung-${v.childId}`,
-        label: `Vertretung (${v.childName.split(" ")[0]})`,
-        start: v.startTime,
-        end: v.endTime,
-      });
-    }
-
     const wd = weekdayIndex(parseIsoDate(date));
     const relevantChildIds =
       childIds.length > 0 ? childIds : dayAssignedChildren.map((c) => c.id);
@@ -208,14 +238,7 @@ export function NewEntrySheet({
     }
 
     return out;
-  }, [
-    date,
-    schedules,
-    dayAssignedChildren,
-    childIds,
-    lastEntry,
-    dayVertretungen,
-  ]);
+  }, [date, schedules, dayAssignedChildren, childIds, lastEntry]);
 
   const submitWithSignature = async (pngBase64: string) => {
     setSubmitting(true);
@@ -258,7 +281,9 @@ export function NewEntrySheet({
 
   const signerSubtitle =
     type === "VERTRETUNG"
-      ? `${date} · Vertretung · ${startTime}–${endTime}`
+      ? `${date} · Vertretung · ${startTime}–${endTime}${
+          duration ? ` · ${duration}` : ""
+        }`
       : type === EventType.WORK
         ? `${date} · ${startTime}–${endTime}${duration ? ` · ${duration}` : ""}`
         : `${date} · Krank · ganztägig`;
@@ -345,9 +370,6 @@ export function NewEntrySheet({
                     placeholder="Vor- und Nachname"
                     autoComplete="off"
                   />
-                  <p className="text-xs text-muted-foreground">
-                    Bitte den Namen so genau wie möglich eingeben.
-                  </p>
                 </div>
 
                 <div className="grid grid-cols-[1fr_auto_1fr] gap-2 items-end">
@@ -379,8 +401,76 @@ export function NewEntrySheet({
                     : "Ende muss nach Start liegen"}
                 </p>
 
+                {availableVertretungen.length > 0 && (
+                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
+                    {availableVertretungen.flatMap((v) =>
+                      v.timeBlocks.map((b, i) => {
+                        const active =
+                          vertretungChildName === v.childName &&
+                          startTime === b.startTime &&
+                          endTime === b.endTime;
+                        return (
+                          <button
+                            key={`${v.childId}-${i}`}
+                            type="button"
+                            onClick={() => {
+                              setVertretungChildName(v.childName);
+                              setStartTime(b.startTime);
+                              setEndTime(b.endTime);
+                            }}
+                            className={cn(
+                              "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors",
+                              active
+                                ? "border-amber-400 bg-amber-400/10 text-foreground"
+                                : "border-border bg-muted/40 hover:bg-accent",
+                            )}
+                          >
+                            <div className="flex flex-col">
+                              <span className="text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                Vertretung
+                              </span>
+                              <span className="font-medium">{v.childName}</span>
+                            </div>
+                            <span className="font-mono tabular-nums text-muted-foreground">
+                              {b.startTime}–{b.endTime}
+                            </span>
+                          </button>
+                        );
+                      }),
+                    )}
+                  </div>
+                )}
+
+                {quickSlots.length > 0 && (
+                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-3">
+                    {quickSlots.map((slot) => (
+                      <button
+                        key={slot.key}
+                        type="button"
+                        onClick={() => {
+                          setStartTime(slot.start);
+                          setEndTime(slot.end);
+                        }}
+                        className={cn(
+                          "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors",
+                          startTime === slot.start && endTime === slot.end
+                            ? "border-amber-400 bg-amber-400/10 text-foreground"
+                            : "border-border bg-muted/40 hover:bg-accent",
+                        )}
+                      >
+                        <span className="font-medium">{slot.label}</span>
+                        <span className="font-mono tabular-nums text-muted-foreground">
+                          {slot.start}–{slot.end}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
                 <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                  Der Antrag wird einem Admin zur Zuordnung weitergeleitet.
+                  Bei exakter Übereinstimmung wird der Eintrag sofort
+                  gespeichert — sonst leiten wir den Antrag an einen Admin
+                  weiter.
                 </div>
               </>
             )}
@@ -398,14 +488,6 @@ export function NewEntrySheet({
                       {dayAssignedChildren[0].firstName}{" "}
                       {dayAssignedChildren[0].lastName}
                     </span>
-                    {dayVertretungen.some(
-                      (v) => v.childId === dayAssignedChildren[0].id,
-                    ) && (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
-                        <UserCheck className="size-3" />
-                        Vertretung
-                      </span>
-                    )}
                   </div>
                 ) : (
                   <div className="space-y-1.5">
@@ -425,12 +507,6 @@ export function NewEntrySheet({
                           <span className="flex-1">
                             {c.firstName} {c.lastName}
                           </span>
-                          {dayVertretungen.some((v) => v.childId === c.id) && (
-                            <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
-                              <UserCheck className="size-3" />
-                              Vertretung
-                            </span>
-                          )}
                         </label>
                       ))}
                     </div>

--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -15,9 +15,14 @@ import {
 } from "@/lib/dates";
 import { WeekStrip } from "./week-strip";
 import { deleteEventAction } from "../actions";
+import { deleteOwnVertretungRequestAction } from "@/features/vertretung-requests/actions";
 import type { Event, Schedule } from "@/generated/prisma";
 import type { ChildOption } from "./children-filter";
-import type { ChildAbsenceItem, VertretungDay } from "./timesheet-shell";
+import type {
+  ChildAbsenceItem,
+  PendingVertretungRequestItem,
+  VertretungDay,
+} from "./timesheet-shell";
 
 type EventWithChild = Event & {
   child: { firstName: string; lastName: string } | null;
@@ -34,6 +39,7 @@ type Props = {
   childAbsences: ChildAbsenceItem[];
   schedules: Schedule[];
   substituteOn?: VertretungDay[];
+  pendingVertretungRequests?: PendingVertretungRequestItem[];
 };
 
 const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -49,6 +55,7 @@ export function TabDay({
   childAbsences,
   schedules,
   substituteOn = [],
+  pendingVertretungRequests = [],
 }: Props) {
   const [busyId, setBusyId] = useState<string | null>(null);
 
@@ -76,37 +83,14 @@ export function TabDay({
       .filter((a): a is ChildAbsenceItem & { child: ChildOption } => !!a.child);
   }, [childAbsences, selectedDateIso, childById]);
 
-  const substituteChildIds = useMemo(
-    () => new Set(substituteOn.map((v) => v.childId)),
-    [substituteOn],
-  );
-
   const daySchedules = useMemo(() => {
     const weekday = (selectedDate.getUTCDay() + 6) % 7;
-    const todaySubstituteChildIds = new Set(
-      substituteOn
-        .filter((v) => v.date === selectedDateIso)
-        .map((v) => v.childId),
-    );
     return schedules
-      .filter((s) => {
-        if (s.weekday !== weekday) return false;
-        if (substituteChildIds.has(s.childId)) {
-          return todaySubstituteChildIds.has(s.childId);
-        }
-        return true;
-      })
+      .filter((s) => s.weekday === weekday)
       .map((s) => ({ ...s, child: childById.get(s.childId) }))
       .filter((s): s is Schedule & { child: ChildOption } => !!s.child)
       .sort((a, b) => a.startTime.localeCompare(b.startTime));
-  }, [
-    schedules,
-    selectedDate,
-    selectedDateIso,
-    childById,
-    substituteChildIds,
-    substituteOn,
-  ]);
+  }, [schedules, selectedDate, childById]);
 
   const dayVertretungenGrouped = useMemo(() => {
     const blocks = substituteOn.filter((v) => v.date === selectedDateIso);
@@ -135,6 +119,23 @@ export function TabDay({
     }
     return Array.from(map.values());
   }, [substituteOn, selectedDateIso]);
+
+  const dayPendingRequests = useMemo(
+    () => pendingVertretungRequests.filter((r) => r.date === selectedDateIso),
+    [pendingVertretungRequests, selectedDateIso],
+  );
+
+  const handleDeleteRequest = async (id: string) => {
+    setBusyId(id);
+    try {
+      await deleteOwnVertretungRequestAction(id);
+      toast.success("Antrag gelöscht.");
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Löschen fehlgeschlagen.");
+    } finally {
+      setBusyId(null);
+    }
+  };
 
   const sickEvent = dayEvents.find((e) => e.type === "SICK");
   const workEvents = dayEvents.filter((e) => e.type === "WORK");
@@ -290,6 +291,37 @@ export function TabDay({
           </div>
         </Card>
       ))}
+
+      {dayPendingRequests
+        .filter((r) => r.status === "PENDING")
+        .map((req) => (
+          <Card
+            key={req.id}
+            className="border-amber-200 bg-amber-500/5 p-4"
+          >
+            <div className="flex items-start gap-3">
+              <div className="grid place-items-center size-10 shrink-0 rounded-full bg-amber-500/15 text-amber-700">
+                <UserCheck className="size-5" />
+              </div>
+              <div className="flex-1 space-y-0.5">
+                <p className="font-semibold text-amber-900">Vertretung</p>
+                <p className="text-sm text-amber-900/80">{req.childNameText}</p>
+                <p className="font-mono text-xs text-amber-700">
+                  {req.startTime}–{req.endTime}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleDeleteRequest(req.id)}
+                disabled={busyId === req.id}
+                className="text-muted-foreground"
+              >
+                Löschen
+              </Button>
+            </div>
+          </Card>
+        ))}
 
       {sickEvent && (
         <Card className="border-rose-200 bg-rose-500/10 p-4">

--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -15,7 +15,10 @@ import {
 } from "@/lib/dates";
 import { WeekStrip } from "./week-strip";
 import { deleteEventAction } from "../actions";
-import { deleteOwnVertretungRequestAction } from "@/features/vertretung-requests/actions";
+import {
+  deleteOwnVertretungAction,
+  deleteOwnVertretungRequestAction,
+} from "@/features/vertretung-requests/actions";
 import type { Event, Schedule } from "@/generated/prisma";
 import type { ChildOption } from "./children-filter";
 import type {
@@ -100,6 +103,7 @@ export function TabDay({
         childId: string;
         childName: string;
         timeBlocks: { startTime: string; endTime: string }[];
+        sbRequestId: string | null;
       }
     >();
     for (const v of blocks) {
@@ -108,11 +112,12 @@ export function TabDay({
           childId: v.childId,
           childName: v.childName,
           timeBlocks: [],
+          sbRequestId: v.sbRequestId ?? null,
         });
       }
-      map
-        .get(v.childId)!
-        .timeBlocks.push({ startTime: v.startTime, endTime: v.endTime });
+      const entry = map.get(v.childId)!;
+      entry.timeBlocks.push({ startTime: v.startTime, endTime: v.endTime });
+      if (v.sbRequestId) entry.sbRequestId = v.sbRequestId;
     }
     for (const entry of map.values()) {
       entry.timeBlocks.sort((a, b) => a.startTime.localeCompare(b.startTime));
@@ -130,6 +135,18 @@ export function TabDay({
     try {
       await deleteOwnVertretungRequestAction(id);
       toast.success("Antrag gelöscht.");
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Löschen fehlgeschlagen.");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDeleteVertretung = async (sbRequestId: string) => {
+    setBusyId(sbRequestId);
+    try {
+      await deleteOwnVertretungAction(sbRequestId);
+      toast.success("Vertretung gelöscht.");
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : "Löschen fehlgeschlagen.");
     } finally {
@@ -288,6 +305,17 @@ export function TabDay({
                   .join(", ")}
               </p>
             </div>
+            {g.sbRequestId && !locked && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleDeleteVertretung(g.sbRequestId!)}
+                disabled={busyId === g.sbRequestId}
+                className="text-muted-foreground"
+              >
+                Löschen
+              </Button>
+            )}
           </div>
         </Card>
       ))}

--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -438,16 +438,7 @@ export function TabDay({
         </Card>
       )}
 
-      {!locked && dayEvents.length > 0 && (
-        <Button
-          onClick={onRequestNewEntry}
-          className="fixed bottom-24 right-4 size-14 rounded-full shadow-lg sm:bottom-6"
-          aria-label="Neuer Eintrag"
-        >
-          <Plus className="size-6" />
-        </Button>
-      )}
-      {!locked && dayEvents.length === 0 && (
+      {!locked && (
         <Button
           onClick={onRequestNewEntry}
           className="fixed bottom-24 right-4 size-14 rounded-full shadow-lg sm:bottom-6"

--- a/src/features/timesheet/components/timesheet-shell.tsx
+++ b/src/features/timesheet/components/timesheet-shell.tsx
@@ -60,6 +60,15 @@ export type VertretungDay = {
   endTime: string;
 };
 
+export type PendingVertretungRequestItem = {
+  id: string;
+  date: string; // YYYY-MM-DD
+  childNameText: string;
+  startTime: string;
+  endTime: string;
+  status: "PENDING" | "RESOLVED";
+};
+
 type Props = {
   currentUser: { id: string; name: string; email: string };
   assignedChildren: ChildOption[];
@@ -70,6 +79,8 @@ type Props = {
   assignmentsByWeekday: AssignmentsByWeekday;
   /** Days this user steps in as substitute Schulbegleiter. */
   substituteOn?: VertretungDay[];
+  /** Own pending Vertretung requests (submitted but not yet resolved by admin). */
+  pendingVertretungRequests?: PendingVertretungRequestItem[];
 };
 
 const NAV_ITEMS: Array<{
@@ -101,6 +112,7 @@ export function SchoolAssistantApp({
   childAbsences,
   assignmentsByWeekday,
   substituteOn = [],
+  pendingVertretungRequests = [],
 }: Props) {
   const today = useMemo(() => startOfDayUtc(new Date()), []);
   const [activeTab, setActiveTab] = useState<Exclude<TabId, "mehr">>("tag");
@@ -174,6 +186,7 @@ export function SchoolAssistantApp({
             childAbsences={childAbsences}
             schedules={schedules}
             substituteOn={substituteOn}
+            pendingVertretungRequests={pendingVertretungRequests}
           />
         );
       case "woche":

--- a/src/features/timesheet/components/timesheet-shell.tsx
+++ b/src/features/timesheet/components/timesheet-shell.tsx
@@ -58,6 +58,10 @@ export type VertretungDay = {
   childName: string;
   startTime: string;
   endTime: string;
+  /** When set, this Vertretung was created by the SB via free-text (auto-matched
+   *  or admin-resolved). The id points at the originating PendingVertretungRequest
+   *  so the SB can fully undo it from the dashboard. */
+  sbRequestId?: string | null;
 };
 
 export type PendingVertretungRequestItem = {
@@ -379,6 +383,7 @@ export function SchoolAssistantApp({
           currentUserName={currentUser.name}
           schedules={schedules}
           substituteOn={substituteOn}
+          events={events}
           lastEntry={
             lastWorkEntry
               ? {

--- a/src/features/timesheet/components/timesheet-shell.tsx
+++ b/src/features/timesheet/components/timesheet-shell.tsx
@@ -152,17 +152,6 @@ export function SchoolAssistantApp({
     setActiveTab(id);
   };
 
-  const lastWorkEntry = useMemo(() => {
-    const work = events.filter(
-      (e) => e.type === "WORK" && e.startTime && e.endTime,
-    );
-    if (work.length === 0) return null;
-    const sorted = [...work].sort(
-      (a, b) => b.date.getTime() - a.date.getTime(),
-    );
-    return sorted[0];
-  }, [events]);
-
   // Work entries an admin created or edited on the Schulbegleiter's behalf are
   // stored without a signatureKey. They await the Schulbegleiter's confirming
   // signature (soft-deleted originals are already filtered server-side).
@@ -384,14 +373,6 @@ export function SchoolAssistantApp({
           schedules={schedules}
           substituteOn={substituteOn}
           events={events}
-          lastEntry={
-            lastWorkEntry
-              ? {
-                  startTime: lastWorkEntry.startTime ?? null,
-                  endTime: lastWorkEntry.endTime ?? null,
-                }
-              : null
-          }
         />
 
         <SettingsDialog

--- a/src/features/timesheet/components/week-grid.tsx
+++ b/src/features/timesheet/components/week-grid.tsx
@@ -51,8 +51,6 @@ export function WeekGrid({
   const monday = startOfWeekUtc(anchorDate);
   const days = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
 
-  const substituteChildIds = new Set(substituteOn.map((v) => v.childId));
-
   const colorFor = (childId: string | null | undefined) => {
     if (!childId) return "bg-rose-500/15 border-rose-400 text-rose-950";
     const idx = childList.findIndex((c) => c.id === childId);
@@ -143,7 +141,7 @@ export function WeekGrid({
             (s) =>
               s.weekday === wd &&
               selectedChildIds.includes(s.childId) &&
-              !substituteChildIds.has(s.childId),
+              !dayVertretungen.some((v) => v.childId === s.childId),
           );
 
           return (

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { prisma } from "@/lib/prisma";
 import {
   ConfirmWorkEventsSchema,
   CreateEventSchema,
@@ -180,7 +181,40 @@ export const TimesheetFacade = {
       event.date.getUTCMonth() + 1,
     );
     assertMonthNotLocked(report);
-    return deleteEventById(eventId);
+    await deleteEventById(eventId);
+
+    if (event.childId) {
+      const weekday = (event.date.getUTCDay() + 6) % 7;
+      const schedule = await prisma.schedule.findFirst({
+        where: { childId: event.childId, weekday },
+        select: { id: true },
+      });
+      if (!schedule) {
+        await prisma.childVertretung.deleteMany({
+          where: {
+            childId: event.childId,
+            date: event.date,
+            substituteUserId: event.userId,
+          },
+        });
+        const sbRequest = await prisma.pendingVertretungRequest.findFirst({
+          where: {
+            substituteUserId: event.userId,
+            date: event.date,
+            OR: [
+              { matchedChildId: event.childId },
+              { resolvedChildId: event.childId },
+            ],
+          },
+          select: { id: true },
+        });
+        if (sbRequest) {
+          await prisma.pendingVertretungRequest.delete({
+            where: { id: sbRequest.id },
+          });
+        }
+      }
+    }
   },
 
   async submitMonthlyReport(userId: string, input: SubmitMonthlyReportInput) {

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -201,6 +201,7 @@ export const TimesheetFacade = {
           where: {
             substituteUserId: event.userId,
             date: event.date,
+            status: { in: ["PENDING", "RESOLVED"] },
             OR: [
               { matchedChildId: event.childId },
               { resolvedChildId: event.childId },

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "crypto";
-import { prisma } from "@/lib/prisma";
 import {
   ConfirmWorkEventsSchema,
   CreateEventSchema,
@@ -182,40 +181,6 @@ export const TimesheetFacade = {
     );
     assertMonthNotLocked(report);
     await deleteEventById(eventId);
-
-    if (event.childId) {
-      const weekday = (event.date.getUTCDay() + 6) % 7;
-      const schedule = await prisma.schedule.findFirst({
-        where: { childId: event.childId, weekday },
-        select: { id: true },
-      });
-      if (!schedule) {
-        await prisma.childVertretung.deleteMany({
-          where: {
-            childId: event.childId,
-            date: event.date,
-            substituteUserId: event.userId,
-          },
-        });
-        const sbRequest = await prisma.pendingVertretungRequest.findFirst({
-          where: {
-            substituteUserId: event.userId,
-            date: event.date,
-            status: { in: ["PENDING", "RESOLVED"] },
-            OR: [
-              { matchedChildId: event.childId },
-              { resolvedChildId: event.childId },
-            ],
-          },
-          select: { id: true },
-        });
-        if (sbRequest) {
-          await prisma.pendingVertretungRequest.delete({
-            where: { id: sbRequest.id },
-          });
-        }
-      }
-    }
   },
 
   async submitMonthlyReport(userId: string, input: SubmitMonthlyReportInput) {

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -109,7 +109,6 @@ export const TimesheetFacade = {
     assertMonthNotLocked(report);
 
     if (parsed.type === "WORK") {
-      const variant = parsed.workVariant ?? "OWN";
       const batchId = randomUUID();
       const signatureKey = `signatures/events/${userId}/${batchId}.png`;
       await uploadSignature(signatureKey, parsed.signaturePngBase64);
@@ -121,7 +120,6 @@ export const TimesheetFacade = {
         endTime: parsed.endTime!,
         note: parsed.note ?? null,
         signatureKey,
-        isSubstitute: variant === "SUBSTITUTE",
       });
       return { createdCount: parsed.childIds.length, signatureKey };
     }

--- a/src/features/timesheet/schemas.ts
+++ b/src/features/timesheet/schemas.ts
@@ -135,3 +135,24 @@ export const ConfirmWorkEventsSchema = z.object({
 });
 
 export type ConfirmWorkEventsInput = z.infer<typeof ConfirmWorkEventsSchema>;
+
+// INDIRECT entry created by free-text child name. The SB types the child's
+// name (same UX as a Vertretung free-text entry). Server resolves it via
+// exact match and rejects if no child is found.
+export const CreateIndirectByNameSchema = z
+  .object({
+    childNameText: z.string().min(2, "Name muss mindestens 2 Zeichen haben."),
+    date: dateStringSchema,
+    startTime: timeStringSchema,
+    endTime: timeStringSchema,
+    note: z.string().min(3, "Notiz ist Pflicht (mind. 3 Zeichen).").max(2000),
+    signaturePngBase64: signatureSchema,
+  })
+  .refine((v) => v.endTime > v.startTime, {
+    message: "Ende muss nach Start liegen.",
+    path: ["endTime"],
+  });
+
+export type CreateIndirectByNameInput = z.infer<
+  typeof CreateIndirectByNameSchema
+>;

--- a/src/features/timesheet/schemas.ts
+++ b/src/features/timesheet/schemas.ts
@@ -15,9 +15,6 @@ const signatureSchema = z
     "Ungültige Signatur.",
   );
 
-export const WorkVariantSchema = z.enum(["OWN", "SUBSTITUTE", "INDIRECT"]);
-export type WorkVariant = z.infer<typeof WorkVariantSchema>;
-
 function isWeekend(dateString: string) {
   const d = new Date(`${dateString}T00:00:00`);
   const dow = d.getDay();
@@ -32,7 +29,6 @@ export const CreateEventSchema = z
     startTime: timeStringSchema.optional(),
     endTime: timeStringSchema.optional(),
     note: z.string().max(2000).optional(),
-    workVariant: WorkVariantSchema.optional(),
     signaturePngBase64: signatureSchema,
   })
   .superRefine((val, ctx) => {
@@ -58,41 +54,18 @@ export const CreateEventSchema = z
     };
 
     if (val.type === "WORK") {
-      const variant = val.workVariant ?? "OWN";
-      if (variant === "OWN") {
-        if (val.childIds.length < 1)
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["childIds"],
-            message: "Mindestens ein Kind auswählen.",
-          });
-        if (isWeekend(val.date))
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["date"],
-            message: "Reguläre Arbeit ist nur an Werktagen möglich.",
-          });
-      } else if (variant === "SUBSTITUTE") {
-        if (val.childIds.length !== 1)
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["childIds"],
-            message: "Genau ein Kind auswählen.",
-          });
-        if (isWeekend(val.date))
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["date"],
-            message: "Einspringen ist nur an Werktagen möglich.",
-          });
-      } else {
+      if (val.childIds.length < 1)
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ["workVariant"],
-          message:
-            "Indirekte Leistung muss mit type=INDIRECT übermittelt werden.",
+          path: ["childIds"],
+          message: "Mindestens ein Kind auswählen.",
         });
-      }
+      if (isWeekend(val.date))
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["date"],
+          message: "Reguläre Arbeit ist nur an Werktagen möglich.",
+        });
       requireTimes();
     }
 

--- a/src/features/timesheet/services/index.ts
+++ b/src/features/timesheet/services/index.ts
@@ -88,7 +88,6 @@ export async function insertWorkEvents(args: {
   endTime: string;
   note?: string | null;
   signatureKey: string;
-  isSubstitute?: boolean;
 }) {
   return prisma.event.createMany({
     data: args.childIds.map((childId) => ({
@@ -100,7 +99,6 @@ export async function insertWorkEvents(args: {
       endTime: args.endTime,
       note: args.note ?? null,
       signatureKey: args.signatureKey,
-      isSubstitute: args.isSubstitute ?? false,
     })),
   });
 }

--- a/src/features/vertretung-requests/actions.ts
+++ b/src/features/vertretung-requests/actions.ts
@@ -23,10 +23,17 @@ export async function resolveVertretungRequestAction(
   const admin = await requireAdmin();
   await VertretungRequestsFacade.resolve(id, admin.id, input);
   revalidatePath("/admin/handlungsbedarf");
+  revalidatePath("/admin/children");
 }
 
 export async function rejectVertretungRequestAction(id: string) {
   const admin = await requireAdmin();
   await VertretungRequestsFacade.reject(id, admin.id);
   revalidatePath("/admin/handlungsbedarf");
+}
+
+export async function deleteOwnVertretungRequestAction(id: string) {
+  const user = await requireAuth();
+  await VertretungRequestsFacade.deleteOwn(id, user.id);
+  revalidatePath("/");
 }

--- a/src/features/vertretung-requests/actions.ts
+++ b/src/features/vertretung-requests/actions.ts
@@ -8,12 +8,22 @@ import type {
   ResolveVertretungRequestInput,
 } from "./schemas";
 
+const VERTRETUNG_REVALIDATE_PATHS = [
+  "/",
+  "/admin/handlungsbedarf",
+  "/admin/children",
+];
+
+function revalidateVertretungPaths() {
+  for (const p of VERTRETUNG_REVALIDATE_PATHS) revalidatePath(p);
+}
+
 export async function createVertretungRequestAction(
   input: CreateVertretungRequestInput,
 ) {
   const user = await requireAuth();
   await VertretungRequestsFacade.create(user.id, input);
-  revalidatePath("/");
+  revalidateVertretungPaths();
 }
 
 export async function resolveVertretungRequestAction(
@@ -22,18 +32,23 @@ export async function resolveVertretungRequestAction(
 ) {
   const admin = await requireAdmin();
   await VertretungRequestsFacade.resolve(id, admin.id, input);
-  revalidatePath("/admin/handlungsbedarf");
-  revalidatePath("/admin/children");
+  revalidateVertretungPaths();
 }
 
 export async function rejectVertretungRequestAction(id: string) {
   const admin = await requireAdmin();
   await VertretungRequestsFacade.reject(id, admin.id);
-  revalidatePath("/admin/handlungsbedarf");
+  revalidateVertretungPaths();
 }
 
 export async function deleteOwnVertretungRequestAction(id: string) {
   const user = await requireAuth();
   await VertretungRequestsFacade.deleteOwn(id, user.id);
-  revalidatePath("/");
+  revalidateVertretungPaths();
+}
+
+export async function deleteOwnVertretungAction(id: string) {
+  const user = await requireAuth();
+  await VertretungRequestsFacade.deleteOwnVertretung(id, user.id);
+  revalidateVertretungPaths();
 }

--- a/src/features/vertretung-requests/actions.ts
+++ b/src/features/vertretung-requests/actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAuth, requireAdmin } from "@/lib/auth-guards";
+import { VertretungRequestsFacade } from "./facade";
+import type {
+  CreateVertretungRequestInput,
+  ResolveVertretungRequestInput,
+} from "./schemas";
+
+export async function createVertretungRequestAction(
+  input: CreateVertretungRequestInput,
+) {
+  const user = await requireAuth();
+  await VertretungRequestsFacade.create(user.id, input);
+  revalidatePath("/");
+}
+
+export async function resolveVertretungRequestAction(
+  id: string,
+  input: ResolveVertretungRequestInput,
+) {
+  const admin = await requireAdmin();
+  await VertretungRequestsFacade.resolve(id, admin.id, input);
+  revalidatePath("/admin/handlungsbedarf");
+}
+
+export async function rejectVertretungRequestAction(id: string) {
+  const admin = await requireAdmin();
+  await VertretungRequestsFacade.reject(id, admin.id);
+  revalidatePath("/admin/handlungsbedarf");
+}

--- a/src/features/vertretung-requests/components/pending-requests-table.tsx
+++ b/src/features/vertretung-requests/components/pending-requests-table.tsx
@@ -32,8 +32,6 @@ type Request = {
   date: string;
   startTime: string;
   endTime: string;
-  matchedChildId: string | null;
-  matchConfidence: number | null;
   substituteUser: { id: string; name: string; email: string };
 };
 
@@ -49,9 +47,7 @@ function RequestRow({
   request: Request;
   childOptions: ChildOption[];
 }) {
-  const [selectedChildId, setSelectedChildId] = useState(
-    request.matchedChildId ?? "",
-  );
+  const [selectedChildId, setSelectedChildId] = useState("");
   const [pending, startTransition] = useTransition();
 
   const handleResolve = () => {
@@ -88,13 +84,6 @@ function RequestRow({
       <TableCell className="tabular-nums">{request.date}</TableCell>
       <TableCell className="tabular-nums">
         {request.startTime}–{request.endTime}
-      </TableCell>
-      <TableCell>
-        {request.matchConfidence !== null && (
-          <span className="text-xs text-muted-foreground">
-            {Math.round(request.matchConfidence * 100)}%
-          </span>
-        )}
       </TableCell>
       <TableCell className="min-w-48">
         <Select
@@ -158,7 +147,6 @@ export function PendingRequestsTable({ requests, childOptions }: Props) {
           <TableHead>Eingegebener Name</TableHead>
           <TableHead>Datum</TableHead>
           <TableHead>Zeiten</TableHead>
-          <TableHead>Konfidenz</TableHead>
           <TableHead>Kind zuordnen</TableHead>
           <TableHead />
         </TableRow>

--- a/src/features/vertretung-requests/components/pending-requests-table.tsx
+++ b/src/features/vertretung-requests/components/pending-requests-table.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Check, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  resolveVertretungRequestAction,
+  rejectVertretungRequestAction,
+} from "../actions";
+
+type ChildOption = { id: string; firstName: string; lastName: string };
+
+type Request = {
+  id: string;
+  childNameText: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  matchedChildId: string | null;
+  matchConfidence: number | null;
+  substituteUser: { id: string; name: string; email: string };
+};
+
+type Props = {
+  requests: Request[];
+  childOptions: ChildOption[];
+};
+
+function RequestRow({
+  request,
+  childOptions,
+}: {
+  request: Request;
+  childOptions: ChildOption[];
+}) {
+  const [selectedChildId, setSelectedChildId] = useState(
+    request.matchedChildId ?? "",
+  );
+  const [pending, startTransition] = useTransition();
+
+  const handleResolve = () => {
+    if (!selectedChildId) return;
+    startTransition(async () => {
+      try {
+        await resolveVertretungRequestAction(request.id, {
+          childId: selectedChildId,
+        });
+        toast.success("Zuordnung gespeichert.");
+      } catch (e: unknown) {
+        toast.error(e instanceof Error ? e.message : "Fehler beim Speichern.");
+      }
+    });
+  };
+
+  const handleReject = () => {
+    startTransition(async () => {
+      try {
+        await rejectVertretungRequestAction(request.id);
+        toast.success("Antrag abgelehnt.");
+      } catch (e: unknown) {
+        toast.error(e instanceof Error ? e.message : "Fehler.");
+      }
+    });
+  };
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">
+        {request.substituteUser.name}
+      </TableCell>
+      <TableCell>{request.childNameText}</TableCell>
+      <TableCell className="tabular-nums">{request.date}</TableCell>
+      <TableCell className="tabular-nums">
+        {request.startTime}–{request.endTime}
+      </TableCell>
+      <TableCell>
+        {request.matchConfidence !== null && (
+          <span className="text-xs text-muted-foreground">
+            {Math.round(request.matchConfidence * 100)}%
+          </span>
+        )}
+      </TableCell>
+      <TableCell className="min-w-48">
+        <Select
+          value={selectedChildId}
+          onValueChange={setSelectedChildId}
+        >
+          <SelectTrigger className="h-8 text-sm">
+            <SelectValue placeholder="Kind wählen…" />
+          </SelectTrigger>
+          <SelectContent>
+            {childOptions.map((c) => (
+              <SelectItem
+                key={c.id}
+                value={c.id}
+              >
+                {c.firstName} {c.lastName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </TableCell>
+      <TableCell>
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            disabled={!selectedChildId || pending}
+            onClick={handleResolve}
+            className="h-8"
+          >
+            <Check className="size-3.5" /> Zuordnen
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={handleReject}
+            className="h-8 text-destructive hover:text-destructive"
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function PendingRequestsTable({ requests, childOptions }: Props) {
+  if (requests.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-6 text-center">
+        Keine offenen Vertretungs-Anträge.
+      </p>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Schulbegleiter</TableHead>
+          <TableHead>Eingegebener Name</TableHead>
+          <TableHead>Datum</TableHead>
+          <TableHead>Zeiten</TableHead>
+          <TableHead>Konfidenz</TableHead>
+          <TableHead>Kind zuordnen</TableHead>
+          <TableHead />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {requests.map((r) => (
+          <RequestRow
+            key={r.id}
+            request={r}
+            childOptions={childOptions}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/features/vertretung-requests/components/pending-requests-table.tsx
+++ b/src/features/vertretung-requests/components/pending-requests-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { Check, X } from "lucide-react";
+import { Check, ChevronsUpDown, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,12 +13,19 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
 import {
   resolveVertretungRequestAction,
   rejectVertretungRequestAction,
@@ -39,6 +46,77 @@ type Props = {
   requests: Request[];
   childOptions: ChildOption[];
 };
+
+function ChildPicker({
+  childOptions,
+  value,
+  onChange,
+  defaultQuery,
+}: {
+  childOptions: ChildOption[];
+  value: string;
+  onChange: (id: string) => void;
+  defaultQuery: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = childOptions.find((c) => c.id === value);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          size="sm"
+          className="h-8 w-full justify-between font-normal"
+        >
+          <span className={cn(!selected && "text-muted-foreground")}>
+            {selected
+              ? `${selected.firstName} ${selected.lastName}`
+              : "Kind wählen…"}
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-(--radix-popover-trigger-width) min-w-(--radix-popover-trigger-width) p-0"
+        align="start"
+      >
+        <Command defaultValue={defaultQuery}>
+          <CommandInput placeholder="Vor- oder Nachname tippen…" />
+          <CommandList>
+            <CommandEmpty>Keine Treffer.</CommandEmpty>
+            <CommandGroup>
+              {childOptions.map((c) => (
+                <CommandItem
+                  key={c.id}
+                  value={`${c.firstName} ${c.lastName}`}
+                  onSelect={() => {
+                    onChange(c.id === value ? "" : c.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 size-4",
+                      value === c.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {c.firstName} {c.lastName}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 function RequestRow({
   request,
@@ -86,24 +164,12 @@ function RequestRow({
         {request.startTime}–{request.endTime}
       </TableCell>
       <TableCell className="min-w-48">
-        <Select
+        <ChildPicker
+          childOptions={childOptions}
           value={selectedChildId}
-          onValueChange={setSelectedChildId}
-        >
-          <SelectTrigger className="h-8 text-sm">
-            <SelectValue placeholder="Kind wählen…" />
-          </SelectTrigger>
-          <SelectContent>
-            {childOptions.map((c) => (
-              <SelectItem
-                key={c.id}
-                value={c.id}
-              >
-                {c.firstName} {c.lastName}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={setSelectedChildId}
+          defaultQuery={request.childNameText}
+        />
       </TableCell>
       <TableCell>
         <div className="flex gap-1">

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "crypto";
+import { uploadSignaturePng } from "@/lib/storage";
+import { prisma } from "@/lib/prisma";
+import {
+  fuzzyMatchChild,
+  MATCH_AUTO_THRESHOLD,
+} from "@/features/children/services/fuzzy-match";
+import {
+  CreateVertretungRequestSchema,
+  ResolveVertretungRequestSchema,
+  type CreateVertretungRequestInput,
+  type ResolveVertretungRequestInput,
+} from "./schemas";
+import {
+  createPendingVertretungRequest,
+  findRequestById,
+  listPendingRequests,
+  rejectRequest,
+  resolveRequest,
+  countPendingRequests,
+} from "./services";
+import { PendingVertretungStatus } from "@/generated/prisma";
+
+function parseDateOnly(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+export const VertretungRequestsFacade = {
+  async create(substituteUserId: string, input: CreateVertretungRequestInput) {
+    const parsed = CreateVertretungRequestSchema.parse(input);
+
+    const signatureKey = `signatures/vertretung-requests/${randomUUID()}.png`;
+    await uploadSignaturePng(signatureKey, parsed.signaturePngBase64);
+
+    const match = await fuzzyMatchChild(parsed.childNameText);
+    const autoResolved =
+      match !== null && match.confidence >= MATCH_AUTO_THRESHOLD;
+
+    const date = parseDateOnly(parsed.date);
+
+    if (autoResolved && match) {
+      // High confidence — create ChildVertretung immediately and store as RESOLVED.
+      const weekday = (date.getUTCDay() + 6) % 7;
+      const schedules = await prisma.schedule.findMany({
+        where: { childId: match.childId, weekday },
+        select: { startTime: true, endTime: true },
+      });
+
+      const timeBlocks =
+        schedules.length > 0
+          ? schedules.map((s) => ({
+              startTime: s.startTime,
+              endTime: s.endTime,
+            }))
+          : [{ startTime: parsed.startTime, endTime: parsed.endTime }];
+
+      await prisma.childVertretung.createMany({
+        data: timeBlocks.map((b) => ({
+          childId: match.childId,
+          substituteUserId,
+          date,
+          startTime: b.startTime,
+          endTime: b.endTime,
+        })),
+      });
+
+      return createPendingVertretungRequest({
+        substituteUserId,
+        childNameText: parsed.childNameText,
+        date,
+        startTime: parsed.startTime,
+        endTime: parsed.endTime,
+        signatureKey,
+        matchedChildId: match.childId,
+        matchConfidence: match.confidence,
+        status: PendingVertretungStatus.RESOLVED,
+      });
+    }
+
+    return createPendingVertretungRequest({
+      substituteUserId,
+      childNameText: parsed.childNameText,
+      date,
+      startTime: parsed.startTime,
+      endTime: parsed.endTime,
+      signatureKey,
+      matchedChildId: match?.childId ?? null,
+      matchConfidence: match?.confidence ?? null,
+      status: PendingVertretungStatus.PENDING,
+    });
+  },
+
+  async listPending() {
+    return listPendingRequests();
+  },
+
+  async countPending() {
+    return countPendingRequests();
+  },
+
+  async resolve(
+    id: string,
+    adminUserId: string,
+    input: ResolveVertretungRequestInput,
+  ) {
+    const parsed = ResolveVertretungRequestSchema.parse(input);
+
+    const request = await findRequestById(id);
+    if (!request) throw new Error("Antrag nicht gefunden.");
+    if (request.status !== PendingVertretungStatus.PENDING) {
+      throw new Error("Dieser Antrag wurde bereits bearbeitet.");
+    }
+
+    const date = request.date;
+    const weekday = (date.getUTCDay() + 6) % 7;
+    const schedules = await prisma.schedule.findMany({
+      where: { childId: parsed.childId, weekday },
+      select: { startTime: true, endTime: true },
+    });
+
+    const timeBlocks =
+      schedules.length > 0
+        ? schedules.map((s) => ({ startTime: s.startTime, endTime: s.endTime }))
+        : [{ startTime: request.startTime, endTime: request.endTime }];
+
+    await prisma.childVertretung.createMany({
+      data: timeBlocks.map((b) => ({
+        childId: parsed.childId,
+        substituteUserId: request.substituteUserId,
+        date,
+        startTime: b.startTime,
+        endTime: b.endTime,
+      })),
+    });
+
+    return resolveRequest(id, parsed.childId, adminUserId);
+  },
+
+  async reject(id: string, adminUserId: string) {
+    const request = await findRequestById(id);
+    if (!request) throw new Error("Antrag nicht gefunden.");
+    if (request.status !== PendingVertretungStatus.PENDING) {
+      throw new Error("Dieser Antrag wurde bereits bearbeitet.");
+    }
+    return rejectRequest(id, adminUserId);
+  },
+};

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -25,6 +25,28 @@ function parseDateOnly(dateStr: string): Date {
   return new Date(Date.UTC(y, m - 1, d));
 }
 
+function createWorkEvent(args: {
+  childId: string;
+  userId: string;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  signatureKey: string;
+}) {
+  return prisma.event.create({
+    data: {
+      childId: args.childId,
+      userId: args.userId,
+      type: "WORK",
+      date: args.date,
+      startTime: args.startTime,
+      endTime: args.endTime,
+      signatureKey: args.signatureKey,
+      deleted: false,
+    },
+  });
+}
+
 export const VertretungRequestsFacade = {
   async create(substituteUserId: string, input: CreateVertretungRequestInput) {
     const parsed = CreateVertretungRequestSchema.parse(input);
@@ -36,7 +58,29 @@ export const VertretungRequestsFacade = {
     const date = parseDateOnly(parsed.date);
 
     if (match) {
-      // Exact name match — create ChildVertretung immediately and store as RESOLVED.
+      // If a Vertretung already exists for this SB+child+date, leave it alone —
+      // it was either set up by the admin or by a prior SB submission. Just
+      // create the work Event and skip the request entirely. This preserves
+      // the admin's assignment intact (no overwriting, no delete button).
+      const existingVertretung = await prisma.childVertretung.findFirst({
+        where: { childId: match.childId, date, substituteUserId },
+        select: { id: true },
+      });
+      if (existingVertretung) {
+        await createWorkEvent({
+          childId: match.childId,
+          userId: substituteUserId,
+          date,
+          startTime: parsed.startTime,
+          endTime: parsed.endTime,
+          signatureKey,
+        });
+        return null;
+      }
+
+      // Exact name match, no prior assignment — create ChildVertretung + Event
+      // and store the request as RESOLVED so the SB can later undo from the
+      // dashboard if it was a mistake.
       const weekday = (date.getUTCDay() + 6) % 7;
       const schedules = await prisma.schedule.findMany({
         where: { childId: match.childId, weekday },
@@ -51,9 +95,6 @@ export const VertretungRequestsFacade = {
             }))
           : [{ startTime: parsed.startTime, endTime: parsed.endTime }];
 
-      await prisma.childVertretung.deleteMany({
-        where: { childId: match.childId, date, substituteUserId },
-      });
       await prisma.childVertretung.createMany({
         data: timeBlocks.map((b) => ({
           childId: match.childId,
@@ -64,17 +105,13 @@ export const VertretungRequestsFacade = {
         })),
       });
 
-      await prisma.event.create({
-        data: {
-          childId: match.childId,
-          userId: substituteUserId,
-          type: "WORK",
-          date,
-          startTime: parsed.startTime,
-          endTime: parsed.endTime,
-          signatureKey,
-          deleted: false,
-        },
+      await createWorkEvent({
+        childId: match.childId,
+        userId: substituteUserId,
+        date,
+        startTime: parsed.startTime,
+        endTime: parsed.endTime,
+        signatureKey,
       });
 
       return createPendingVertretungRequest({
@@ -156,17 +193,13 @@ export const VertretungRequestsFacade = {
 
     // Create a signed work Event so the Einsatz appears in the child's calendar.
     // The SB already signed the request — reuse the same signatureKey.
-    await prisma.event.create({
-      data: {
-        childId: parsed.childId,
-        userId: request.substituteUserId,
-        type: "WORK",
-        date,
-        startTime: request.startTime,
-        endTime: request.endTime,
-        signatureKey: request.signatureKey,
-        deleted: false,
-      },
+    await createWorkEvent({
+      childId: parsed.childId,
+      userId: request.substituteUserId,
+      date,
+      startTime: request.startTime,
+      endTime: request.endTime,
+      signatureKey: request.signatureKey,
     });
 
     return resolveRequest(id, parsed.childId, adminUserId);
@@ -178,6 +211,42 @@ export const VertretungRequestsFacade = {
 
   async deleteOwn(id: string, userId: string) {
     return deleteOwnRequest(id, userId);
+  },
+
+  /**
+   * Fully undoes a Vertretung the SB created via free-text (auto-matched or
+   * admin-resolved): removes the linked work Event, the ChildVertretung
+   * block(s), and the PendingVertretungRequest record itself.
+   */
+  async deleteOwnVertretung(requestId: string, userId: string) {
+    const request = await prisma.pendingVertretungRequest.findUnique({
+      where: { id: requestId },
+    });
+    if (!request) throw new Error("Antrag nicht gefunden.");
+    if (request.substituteUserId !== userId) {
+      throw new Error("Keine Berechtigung.");
+    }
+
+    const childId = request.resolvedChildId ?? request.matchedChildId;
+    if (childId) {
+      await prisma.event.deleteMany({
+        where: {
+          userId,
+          childId,
+          date: request.date,
+          type: "WORK",
+        },
+      });
+      await prisma.childVertretung.deleteMany({
+        where: {
+          substituteUserId: userId,
+          childId,
+          date: request.date,
+        },
+      });
+    }
+
+    await prisma.pendingVertretungRequest.delete({ where: { id: requestId } });
   },
 
   async reject(id: string, adminUserId: string) {

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "crypto";
 import { uploadSignaturePng } from "@/lib/storage";
-import { prisma } from "@/lib/prisma";
 import { exactMatchChild } from "@/lib/child-matching";
 import {
   CreateVertretungRequestSchema,
@@ -9,42 +8,27 @@ import {
   type ResolveVertretungRequestInput,
 } from "./schemas";
 import {
+  countPendingRequests,
   createPendingVertretungRequest,
+  deleteChildVertretungForSubstitute,
   deleteOwnRequest,
+  deletePendingVertretungRequestById,
+  deleteWorkEventsForSubstituteOnDate,
+  findExistingVertretungForSubstitute,
   findRequestById,
+  getScheduleTimeBlocks,
+  insertChildVertretungBlocks,
+  insertVertretungWorkEvent,
   listPendingRequests,
   listRequestsForUser,
   rejectRequest,
   resolveRequest,
-  countPendingRequests,
 } from "./services";
 import { PendingVertretungStatus } from "@/generated/prisma";
 
 function parseDateOnly(dateStr: string): Date {
   const [y, m, d] = dateStr.split("-").map(Number);
   return new Date(Date.UTC(y, m - 1, d));
-}
-
-function createWorkEvent(args: {
-  childId: string;
-  userId: string;
-  date: Date;
-  startTime: string;
-  endTime: string;
-  signatureKey: string;
-}) {
-  return prisma.event.create({
-    data: {
-      childId: args.childId,
-      userId: args.userId,
-      type: "WORK",
-      date: args.date,
-      startTime: args.startTime,
-      endTime: args.endTime,
-      signatureKey: args.signatureKey,
-      deleted: false,
-    },
-  });
 }
 
 export const VertretungRequestsFacade = {
@@ -62,12 +46,13 @@ export const VertretungRequestsFacade = {
       // it was either set up by the admin or by a prior SB submission. Just
       // create the work Event and skip the request entirely. This preserves
       // the admin's assignment intact (no overwriting, no delete button).
-      const existingVertretung = await prisma.childVertretung.findFirst({
-        where: { childId: match.childId, date, substituteUserId },
-        select: { id: true },
+      const existingVertretung = await findExistingVertretungForSubstitute({
+        childId: match.childId,
+        date,
+        substituteUserId,
       });
       if (existingVertretung) {
-        await createWorkEvent({
+        await insertVertretungWorkEvent({
           childId: match.childId,
           userId: substituteUserId,
           date,
@@ -82,10 +67,7 @@ export const VertretungRequestsFacade = {
       // and store the request as RESOLVED so the SB can later undo from the
       // dashboard if it was a mistake.
       const weekday = (date.getUTCDay() + 6) % 7;
-      const schedules = await prisma.schedule.findMany({
-        where: { childId: match.childId, weekday },
-        select: { startTime: true, endTime: true },
-      });
+      const schedules = await getScheduleTimeBlocks(match.childId, weekday);
 
       const timeBlocks =
         schedules.length > 0
@@ -95,17 +77,14 @@ export const VertretungRequestsFacade = {
             }))
           : [{ startTime: parsed.startTime, endTime: parsed.endTime }];
 
-      await prisma.childVertretung.createMany({
-        data: timeBlocks.map((b) => ({
-          childId: match.childId,
-          substituteUserId,
-          date,
-          startTime: b.startTime,
-          endTime: b.endTime,
-        })),
+      await insertChildVertretungBlocks({
+        childId: match.childId,
+        substituteUserId,
+        date,
+        blocks: timeBlocks,
       });
 
-      await createWorkEvent({
+      await insertVertretungWorkEvent({
         childId: match.childId,
         userId: substituteUserId,
         date,
@@ -164,36 +143,28 @@ export const VertretungRequestsFacade = {
 
     const date = request.date;
     const weekday = (date.getUTCDay() + 6) % 7;
-    const schedules = await prisma.schedule.findMany({
-      where: { childId: parsed.childId, weekday },
-      select: { startTime: true, endTime: true },
-    });
+    const schedules = await getScheduleTimeBlocks(parsed.childId, weekday);
 
     const timeBlocks =
       schedules.length > 0
         ? schedules.map((s) => ({ startTime: s.startTime, endTime: s.endTime }))
         : [{ startTime: request.startTime, endTime: request.endTime }];
 
-    await prisma.childVertretung.deleteMany({
-      where: {
-        childId: parsed.childId,
-        date,
-        substituteUserId: request.substituteUserId,
-      },
+    await deleteChildVertretungForSubstitute({
+      childId: parsed.childId,
+      substituteUserId: request.substituteUserId,
+      date,
     });
-    await prisma.childVertretung.createMany({
-      data: timeBlocks.map((b) => ({
-        childId: parsed.childId,
-        substituteUserId: request.substituteUserId,
-        date,
-        startTime: b.startTime,
-        endTime: b.endTime,
-      })),
+    await insertChildVertretungBlocks({
+      childId: parsed.childId,
+      substituteUserId: request.substituteUserId,
+      date,
+      blocks: timeBlocks,
     });
 
     // Create a signed work Event so the Einsatz appears in the child's calendar.
     // The SB already signed the request — reuse the same signatureKey.
-    await createWorkEvent({
+    await insertVertretungWorkEvent({
       childId: parsed.childId,
       userId: request.substituteUserId,
       date,
@@ -219,9 +190,7 @@ export const VertretungRequestsFacade = {
    * block(s), and the PendingVertretungRequest record itself.
    */
   async deleteOwnVertretung(requestId: string, userId: string) {
-    const request = await prisma.pendingVertretungRequest.findUnique({
-      where: { id: requestId },
-    });
+    const request = await findRequestById(requestId);
     if (!request) throw new Error("Antrag nicht gefunden.");
     if (request.substituteUserId !== userId) {
       throw new Error("Keine Berechtigung.");
@@ -229,24 +198,19 @@ export const VertretungRequestsFacade = {
 
     const childId = request.resolvedChildId ?? request.matchedChildId;
     if (childId) {
-      await prisma.event.deleteMany({
-        where: {
-          userId,
-          childId,
-          date: request.date,
-          type: "WORK",
-        },
+      await deleteWorkEventsForSubstituteOnDate({
+        userId,
+        childId,
+        date: request.date,
       });
-      await prisma.childVertretung.deleteMany({
-        where: {
-          substituteUserId: userId,
-          childId,
-          date: request.date,
-        },
+      await deleteChildVertretungForSubstitute({
+        childId,
+        substituteUserId: userId,
+        date: request.date,
       });
     }
 
-    await prisma.pendingVertretungRequest.delete({ where: { id: requestId } });
+    await deletePendingVertretungRequestById(requestId);
   },
 
   async reject(id: string, adminUserId: string) {

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "crypto";
 import { uploadSignaturePng } from "@/lib/storage";
 import { prisma } from "@/lib/prisma";
-import {
-  fuzzyMatchChild,
-  MATCH_AUTO_THRESHOLD,
-} from "@/features/children/services/fuzzy-match";
+import { exactMatchChild } from "@/features/children/services/fuzzy-match";
 import {
   CreateVertretungRequestSchema,
   ResolveVertretungRequestSchema,
@@ -13,8 +10,10 @@ import {
 } from "./schemas";
 import {
   createPendingVertretungRequest,
+  deleteOwnRequest,
   findRequestById,
   listPendingRequests,
+  listRequestsForUser,
   rejectRequest,
   resolveRequest,
   countPendingRequests,
@@ -33,14 +32,11 @@ export const VertretungRequestsFacade = {
     const signatureKey = `signatures/vertretung-requests/${randomUUID()}.png`;
     await uploadSignaturePng(signatureKey, parsed.signaturePngBase64);
 
-    const match = await fuzzyMatchChild(parsed.childNameText);
-    const autoResolved =
-      match !== null && match.confidence >= MATCH_AUTO_THRESHOLD;
-
+    const match = await exactMatchChild(parsed.childNameText);
     const date = parseDateOnly(parsed.date);
 
-    if (autoResolved && match) {
-      // High confidence — create ChildVertretung immediately and store as RESOLVED.
+    if (match) {
+      // Exact name match — create ChildVertretung immediately and store as RESOLVED.
       const weekday = (date.getUTCDay() + 6) % 7;
       const schedules = await prisma.schedule.findMany({
         where: { childId: match.childId, weekday },
@@ -55,6 +51,9 @@ export const VertretungRequestsFacade = {
             }))
           : [{ startTime: parsed.startTime, endTime: parsed.endTime }];
 
+      await prisma.childVertretung.deleteMany({
+        where: { childId: match.childId, date, substituteUserId },
+      });
       await prisma.childVertretung.createMany({
         data: timeBlocks.map((b) => ({
           childId: match.childId,
@@ -65,6 +64,19 @@ export const VertretungRequestsFacade = {
         })),
       });
 
+      await prisma.event.create({
+        data: {
+          childId: match.childId,
+          userId: substituteUserId,
+          type: "WORK",
+          date,
+          startTime: parsed.startTime,
+          endTime: parsed.endTime,
+          signatureKey,
+          deleted: false,
+        },
+      });
+
       return createPendingVertretungRequest({
         substituteUserId,
         childNameText: parsed.childNameText,
@@ -73,11 +85,12 @@ export const VertretungRequestsFacade = {
         endTime: parsed.endTime,
         signatureKey,
         matchedChildId: match.childId,
-        matchConfidence: match.confidence,
+        matchConfidence: null,
         status: PendingVertretungStatus.RESOLVED,
       });
     }
 
+    // No exact match — goes to admin queue.
     return createPendingVertretungRequest({
       substituteUserId,
       childNameText: parsed.childNameText,
@@ -85,8 +98,8 @@ export const VertretungRequestsFacade = {
       startTime: parsed.startTime,
       endTime: parsed.endTime,
       signatureKey,
-      matchedChildId: match?.childId ?? null,
-      matchConfidence: match?.confidence ?? null,
+      matchedChildId: null,
+      matchConfidence: null,
       status: PendingVertretungStatus.PENDING,
     });
   },
@@ -124,6 +137,13 @@ export const VertretungRequestsFacade = {
         ? schedules.map((s) => ({ startTime: s.startTime, endTime: s.endTime }))
         : [{ startTime: request.startTime, endTime: request.endTime }];
 
+    await prisma.childVertretung.deleteMany({
+      where: {
+        childId: parsed.childId,
+        date,
+        substituteUserId: request.substituteUserId,
+      },
+    });
     await prisma.childVertretung.createMany({
       data: timeBlocks.map((b) => ({
         childId: parsed.childId,
@@ -134,7 +154,30 @@ export const VertretungRequestsFacade = {
       })),
     });
 
+    // Create a signed work Event so the Einsatz appears in the child's calendar.
+    // The SB already signed the request — reuse the same signatureKey.
+    await prisma.event.create({
+      data: {
+        childId: parsed.childId,
+        userId: request.substituteUserId,
+        type: "WORK",
+        date,
+        startTime: request.startTime,
+        endTime: request.endTime,
+        signatureKey: request.signatureKey,
+        deleted: false,
+      },
+    });
+
     return resolveRequest(id, parsed.childId, adminUserId);
+  },
+
+  async listForUser(userId: string, from: Date, to: Date) {
+    return listRequestsForUser(userId, from, to);
+  },
+
+  async deleteOwn(id: string, userId: string) {
+    return deleteOwnRequest(id, userId);
   },
 
   async reject(id: string, adminUserId: string) {

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { uploadSignaturePng } from "@/lib/storage";
 import { prisma } from "@/lib/prisma";
-import { exactMatchChild } from "@/features/children/services/fuzzy-match";
+import { exactMatchChild } from "@/lib/child-matching";
 import {
   CreateVertretungRequestSchema,
   ResolveVertretungRequestSchema,

--- a/src/features/vertretung-requests/index.ts
+++ b/src/features/vertretung-requests/index.ts
@@ -1,0 +1,1 @@
+export { VertretungRequestsFacade } from "./facade";

--- a/src/features/vertretung-requests/schemas.ts
+++ b/src/features/vertretung-requests/schemas.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const CreateVertretungRequestSchema = z.object({
+  childNameText: z.string().min(2, "Name muss mindestens 2 Zeichen haben."),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Ungültiges Datum."),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/, "Ungültige Startzeit."),
+  endTime: z.string().regex(/^\d{2}:\d{2}$/, "Ungültige Endzeit."),
+  signaturePngBase64: z.string().min(1, "Unterschrift fehlt."),
+});
+
+export type CreateVertretungRequestInput = z.infer<
+  typeof CreateVertretungRequestSchema
+>;
+
+export const ResolveVertretungRequestSchema = z.object({
+  childId: z.string().min(1, "Kind muss ausgewählt werden."),
+});
+
+export type ResolveVertretungRequestInput = z.infer<
+  typeof ResolveVertretungRequestSchema
+>;

--- a/src/features/vertretung-requests/services/index.ts
+++ b/src/features/vertretung-requests/services/index.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { PendingVertretungStatus } from "@/generated/prisma";
+import { EventType, PendingVertretungStatus } from "@/generated/prisma";
 
 export async function createPendingVertretungRequest(data: {
   substituteUserId: string;
@@ -91,4 +91,98 @@ export async function deleteOwnRequest(id: string, substituteUserId: string) {
     throw new Error("Nur offene Anträge können gelöscht werden.");
   }
   await prisma.pendingVertretungRequest.delete({ where: { id } });
+}
+
+export async function deletePendingVertretungRequestById(id: string) {
+  return prisma.pendingVertretungRequest.delete({ where: { id } });
+}
+
+export async function findExistingVertretungForSubstitute(args: {
+  childId: string;
+  date: Date;
+  substituteUserId: string;
+}) {
+  return prisma.childVertretung.findFirst({
+    where: {
+      childId: args.childId,
+      date: args.date,
+      substituteUserId: args.substituteUserId,
+    },
+    select: { id: true },
+  });
+}
+
+export async function getScheduleTimeBlocks(childId: string, weekday: number) {
+  return prisma.schedule.findMany({
+    where: { childId, weekday },
+    select: { startTime: true, endTime: true },
+  });
+}
+
+export async function insertChildVertretungBlocks(args: {
+  childId: string;
+  substituteUserId: string;
+  date: Date;
+  blocks: { startTime: string; endTime: string }[];
+}) {
+  return prisma.childVertretung.createMany({
+    data: args.blocks.map((b) => ({
+      childId: args.childId,
+      substituteUserId: args.substituteUserId,
+      date: args.date,
+      startTime: b.startTime,
+      endTime: b.endTime,
+    })),
+  });
+}
+
+export async function deleteChildVertretungForSubstitute(args: {
+  childId: string;
+  substituteUserId: string;
+  date: Date;
+}) {
+  return prisma.childVertretung.deleteMany({
+    where: {
+      childId: args.childId,
+      substituteUserId: args.substituteUserId,
+      date: args.date,
+    },
+  });
+}
+
+export async function insertVertretungWorkEvent(args: {
+  childId: string;
+  userId: string;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  signatureKey: string;
+}) {
+  return prisma.event.create({
+    data: {
+      childId: args.childId,
+      userId: args.userId,
+      type: EventType.WORK,
+      date: args.date,
+      startTime: args.startTime,
+      endTime: args.endTime,
+      signatureKey: args.signatureKey,
+      deleted: false,
+    },
+  });
+}
+
+export async function deleteWorkEventsForSubstituteOnDate(args: {
+  userId: string;
+  childId: string;
+  date: Date;
+}) {
+  return prisma.event.deleteMany({
+    where: {
+      userId: args.userId,
+      childId: args.childId,
+      date: args.date,
+      type: EventType.WORK,
+    },
+  });
 }

--- a/src/features/vertretung-requests/services/index.ts
+++ b/src/features/vertretung-requests/services/index.ts
@@ -61,3 +61,34 @@ export async function countPendingRequests() {
     where: { status: PendingVertretungStatus.PENDING },
   });
 }
+
+export async function listRequestsForUser(
+  substituteUserId: string,
+  from: Date,
+  to: Date,
+) {
+  return prisma.pendingVertretungRequest.findMany({
+    where: {
+      substituteUserId,
+      status: {
+        in: [PendingVertretungStatus.PENDING, PendingVertretungStatus.RESOLVED],
+      },
+      date: { gte: from, lt: to },
+    },
+    orderBy: { date: "asc" },
+  });
+}
+
+export async function deleteOwnRequest(id: string, substituteUserId: string) {
+  const request = await prisma.pendingVertretungRequest.findUnique({
+    where: { id },
+  });
+  if (!request) throw new Error("Antrag nicht gefunden.");
+  if (request.substituteUserId !== substituteUserId) {
+    throw new Error("Keine Berechtigung.");
+  }
+  if (request.status !== PendingVertretungStatus.PENDING) {
+    throw new Error("Nur offene Anträge können gelöscht werden.");
+  }
+  await prisma.pendingVertretungRequest.delete({ where: { id } });
+}

--- a/src/features/vertretung-requests/services/index.ts
+++ b/src/features/vertretung-requests/services/index.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@/lib/prisma";
+import { PendingVertretungStatus } from "@/generated/prisma";
+
+export async function createPendingVertretungRequest(data: {
+  substituteUserId: string;
+  childNameText: string;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  signatureKey: string;
+  matchedChildId: string | null;
+  matchConfidence: number | null;
+  status: PendingVertretungStatus;
+}) {
+  return prisma.pendingVertretungRequest.create({ data });
+}
+
+export async function listPendingRequests() {
+  return prisma.pendingVertretungRequest.findMany({
+    where: { status: PendingVertretungStatus.PENDING },
+    include: {
+      substituteUser: { select: { id: true, name: true, email: true } },
+    },
+    orderBy: { date: "asc" },
+  });
+}
+
+export async function findRequestById(id: string) {
+  return prisma.pendingVertretungRequest.findUnique({ where: { id } });
+}
+
+export async function resolveRequest(
+  id: string,
+  resolvedChildId: string,
+  resolvedByUserId: string,
+) {
+  return prisma.pendingVertretungRequest.update({
+    where: { id },
+    data: {
+      status: PendingVertretungStatus.RESOLVED,
+      resolvedChildId,
+      resolvedByUserId,
+      resolvedAt: new Date(),
+    },
+  });
+}
+
+export async function rejectRequest(id: string, resolvedByUserId: string) {
+  return prisma.pendingVertretungRequest.update({
+    where: { id },
+    data: {
+      status: PendingVertretungStatus.REJECTED,
+      resolvedByUserId,
+      resolvedAt: new Date(),
+    },
+  });
+}
+
+export async function countPendingRequests() {
+  return prisma.pendingVertretungRequest.count({
+    where: { status: PendingVertretungStatus.PENDING },
+  });
+}

--- a/src/lib/child-matching.ts
+++ b/src/lib/child-matching.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@/lib/prisma";
 
-export type MatchResult = {
+export type ChildMatchResult = {
   childId: string;
 };
 
@@ -10,7 +10,7 @@ function normalize(s: string): string {
 
 export async function exactMatchChild(
   nameText: string,
-): Promise<MatchResult | null> {
+): Promise<ChildMatchResult | null> {
   const query = normalize(nameText);
   const children = await prisma.child.findMany({
     select: { id: true, firstName: true, lastName: true },

--- a/src/use-cases/create-indirect-event-by-name.ts
+++ b/src/use-cases/create-indirect-event-by-name.ts
@@ -1,0 +1,42 @@
+/**
+ * Use case: Create an INDIRECT timesheet event from a free-text child name.
+ *
+ * Mirrors the Vertretung-style free-text UX: the SB types the child's name
+ * and the server resolves it via exact match against the Child table. If no
+ * exact match is found the request is rejected — there is no admin queue for
+ * indirect entries (decision: 2026-06-17).
+ *
+ * The resolved childId is then handed to the existing createTimesheetEvent
+ * use case which performs the cross-feature validation and insert.
+ */
+
+import { exactMatchChild } from "@/lib/child-matching";
+import {
+  CreateIndirectByNameSchema,
+  type CreateIndirectByNameInput,
+} from "@/features/timesheet/schemas";
+import { createTimesheetEvent } from "./create-timesheet-event";
+
+export async function createIndirectEventByName(
+  userId: string,
+  input: CreateIndirectByNameInput,
+) {
+  const parsed = CreateIndirectByNameSchema.parse(input);
+
+  const match = await exactMatchChild(parsed.childNameText);
+  if (!match) {
+    throw new Error(
+      `Kein Kind mit dem Namen „${parsed.childNameText.trim()}" gefunden.`,
+    );
+  }
+
+  return createTimesheetEvent(userId, {
+    type: "INDIRECT",
+    date: parsed.date,
+    childIds: [match.childId],
+    startTime: parsed.startTime,
+    endTime: parsed.endTime,
+    note: parsed.note,
+    signaturePngBase64: parsed.signaturePngBase64,
+  });
+}


### PR DESCRIPTION
 School assistants (SB) can now submit substitute (Vertretung) assignments themselves — without
  requiring an admin to pre-assign them.

  SB submits a Vertretung:
  - SB enters the child's name as free text + time + signature
  - If the name matches exactly → the Vertretung is auto-confirmed immediately: ChildVertretung +
  signed Work Event are created on the spot
  - No match → request goes into the admin action queue for manual child assignment

  Admin resolves a request:
  - Admin selects the correct child from a dropdown
  - System creates ChildVertretung + Work Event reusing the SB's original signature

  SB view:
  - PENDING requests appear as an amber "Vertretung" card in the day view with a delete button
  - RESOLVED entries appear as a normal signed grey card (same as regular work entries) 
  
  Delete behaviour:
  - When SB deletes a Vertretung entry, the outcome depends on whether a Stundenplan exists for
  that child:
    - Stundenplan exists (admin proactively assigned) → only the event is deleted, amber block
  stays
    - No Stundenplan (SB self-submitted) → event + ChildVertretung + request are all removed

  Child calendar (admin view):
  - Einsatz blocks now render even when no Stundenplan exists for that weekday