### PR TITLE
fix(school-assistants): sync User.name and child route on rename (COD…

### DIFF
--- a/prisma/migrations/20260612202753_event_replaces_link/migration.sql
+++ b/prisma/migrations/20260612202753_event_replaces_link/migration.sql
@@ -1,0 +1,8 @@
+-- When an admin edits a *signed* event we soft-delete the original and create
+-- a new (unsigned) replacement. This pointer lets `restore` undo the edit by
+-- removing the replacement row alongside un-deleting the original.
+ALTER TABLE `event` ADD COLUMN `replacesEventId` VARCHAR(191) NULL;
+
+CREATE INDEX `event_replacesEventId_idx` ON `event`(`replacesEventId`);
+
+ALTER TABLE `event` ADD CONSTRAINT `event_replacesEventId_fkey` FOREIGN KEY (`replacesEventId`) REFERENCES `event`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -213,24 +213,31 @@ model Schedule {
 }
 
 model Event {
-  id           String    @id @default(cuid())
-  childId      String?
-  userId       String
-  type         EventType
-  date         DateTime  @db.Date
-  startTime    String?
-  endTime      String?
-  note         String?   @db.Text
-  isSubstitute Boolean   @default(false)
-  signatureKey String?   // !null -> by school assistant, null -> by admin
-  deleted      Boolean   @default(false) // soft delete only for signed events; admin-created events are hard deleted
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  child        Child?    @relation(fields: [childId], references: [id])
-  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id              String    @id @default(cuid())
+  childId         String?
+  userId          String
+  type            EventType
+  date            DateTime  @db.Date
+  startTime       String?
+  endTime         String?
+  note            String?   @db.Text
+  isSubstitute    Boolean   @default(false)
+  signatureKey    String?   // !null -> by school assistant, null -> by admin
+  deleted         Boolean   @default(false) // soft delete only for signed events; admin-created events are hard deleted
+  // Set when an admin edits a signed event: the new (unsigned) row points at
+  // the soft-deleted original. Lets `restore` undo the edit by also removing
+  // the replacement.
+  replacesEventId String?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  child           Child?    @relation(fields: [childId], references: [id])
+  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  replaces        Event?    @relation("EventReplacement", fields: [replacesEventId], references: [id], onDelete: SetNull)
+  replacedBy      Event[]   @relation("EventReplacement")
 
   @@index([userId, date])
   @@index([childId, date])
+  @@index([replacesEventId])
   @@map("event")
 }
 

--- a/src/features/children/services/events.ts
+++ b/src/features/children/services/events.ts
@@ -59,6 +59,7 @@ export async function updateWorkEventAsAdmin(
         note: input.note !== undefined ? input.note : existing.note,
         signatureKey: null,
         deleted: false,
+        replacesEventId: existing.id,
       },
     });
   } else {
@@ -90,9 +91,17 @@ export async function deleteWorkEventAsAdmin(id: string) {
 }
 
 export async function restoreWorkEventAsAdmin(id: string) {
-  return prisma.event.update({
-    where: { id },
-    data: { deleted: false },
+  // Undoing an edit: remove any unsigned replacement that was created when
+  // this row was soft-deleted, otherwise both versions would appear in the
+  // calendar.
+  return prisma.$transaction(async (tx) => {
+    await tx.event.deleteMany({
+      where: { replacesEventId: id, signatureKey: null },
+    });
+    return tx.event.update({
+      where: { id },
+      data: { deleted: false },
+    });
   });
 }
 
@@ -102,7 +111,12 @@ export async function listWorkEventsForChildInRange(
   to: Date,
 ): Promise<ChildWorkEvent[]> {
   return prisma.event.findMany({
-    where: { childId, type: EventType.WORK, date: { gte: from, lte: to } },
+    where: {
+      childId,
+      type: EventType.WORK,
+      date: { gte: from, lte: to },
+      deleted: false,
+    },
     include: { user: true },
     orderBy: { date: "asc" },
   });

--- a/src/features/school-assistants/actions.ts
+++ b/src/features/school-assistants/actions.ts
@@ -27,6 +27,9 @@ export async function updateSchoolAssistantAction(
   await requireAdmin();
   await SchoolAssistantsFacade.update(profileId, input);
   revalidatePath(ROUTE);
+  // A rename also affects the assignment chips and Einsatz labels in the
+  // child calendar (which read user.name), so refresh that route too.
+  revalidatePath("/admin/children");
   return { success: true };
 }
 

--- a/src/features/school-assistants/services/index.ts
+++ b/src/features/school-assistants/services/index.ts
@@ -89,10 +89,19 @@ export async function updateProfilePartial(args: {
         });
       }
     }
-    return tx.schoolAssistantProfile.update({
+    const updated = await tx.schoolAssistantProfile.update({
       where: { id: args.profileId },
       data: args.patch,
     });
+    // Keep the linked User.name in sync so assignments, vertretungen and
+    // work events (which read user.name via relations) reflect the rename.
+    if (args.patch.name !== undefined && updated.userId) {
+      await tx.user.update({
+        where: { id: updated.userId },
+        data: { name: args.patch.name },
+      });
+    }
+    return updated;
   });
 }
 


### PR DESCRIPTION
- Renaming a Schulbegleiter no longer leaves a stale name in the child's Kalender. The fix
  mirrors the new name onto the linked `User` record and revalidates `/admin/children` so
  assignment chips and Einsatz labels refresh immediately.


 - Fix duplicate Einsatz blocks in the child week calendar after an admin edits a signed entry —
  the soft-deleted original was still being rendered alongside the new replacement. Added deleted:
   false to listWorkEventsForChildInRange.
  - Fix the same duplication after using Undo in the History tab to revert an edit — both the
  restored original and the edit-replacement remained active. Added a self-referential
  replacesEventId FK on Event so restoreWorkEventAsAdmin can hard-delete the replacement inside a
  transaction while un-deleting the original.
  - Adds Prisma migration 20260612202753_event_replaces_link (column + index + FK with ON DELETE 
  SET NULL).