### PR TITLE
feat(handlungsbedarf) + Bugfix indirekte Leistung

### DIFF
--- a/prisma/migrations/20260630104926_add_pending_request_kind_and_note/migration.sql
+++ b/prisma/migrations/20260630104926_add_pending_request_kind_and_note/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE `pending_vertretung_request` ADD COLUMN `kind` ENUM('VERTRETUNG', 'INDIRECT') NOT NULL DEFAULT 'VERTRETUNG',
+    ADD COLUMN `note` VARCHAR(191) NULL;
+
+-- CreateIndex
+CREATE INDEX `pending_vertretung_request_kind_status_date_idx` ON `pending_vertretung_request`(`kind`, `status`, `date`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,11 @@ enum PendingVertretungStatus {
   REJECTED
 }
 
+enum PendingRequestKind {
+  VERTRETUNG
+  INDIRECT
+}
+
 model User {
   id                         String                     @id
   name                       String
@@ -393,12 +398,14 @@ model WorkshopAttendance {
 
 model PendingVertretungRequest {
   id               String                  @id @default(cuid())
+  kind             PendingRequestKind      @default(VERTRETUNG)
   substituteUserId String
   childNameText    String
   date             DateTime                @db.Date
   startTime        String
   endTime          String
   signatureKey     String
+  note             String?
   matchedChildId   String?
   matchConfidence  Float?
   status           PendingVertretungStatus @default(PENDING)
@@ -412,5 +419,6 @@ model PendingVertretungRequest {
 
   @@index([substituteUserId, status])
   @@index([status, date])
+  @@index([kind, status, date])
   @@map("pending_vertretung_request")
 }

--- a/src/app/admin/handlungsbedarf/page.tsx
+++ b/src/app/admin/handlungsbedarf/page.tsx
@@ -1,17 +1,39 @@
 import { requireAdmin } from "@/lib/auth-guards";
 import { VertretungRequestsFacade } from "@/features/vertretung-requests";
 import { ChildrenFacade } from "@/features/children";
+import { SchoolAssistantsFacade } from "@/features/school-assistants";
+import { HandlungsbedarfFacade } from "@/features/handlungsbedarf";
 import { PendingRequestsTable } from "@/features/vertretung-requests/components/pending-requests-table";
 import { PendingIndirectRequestsTable } from "@/features/vertretung-requests/components/pending-indirect-requests-table";
+import { SickFlagsList } from "@/features/handlungsbedarf/components/sick-flags-list";
+import { OtherFlagsList } from "@/features/handlungsbedarf/components/other-flags-list";
 import { PageSection } from "@/components/page-section";
+
+const WINDOW_DAYS = 7;
 
 export default async function HandlungsbedarfPage() {
   await requireAdmin();
 
-  const [rawRequests, rawIndirectRequests, children] = await Promise.all([
+  const now = new Date();
+  const from = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const to = new Date(from.getTime() + WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  const [
+    rawRequests,
+    rawIndirectRequests,
+    children,
+    schoolAssistants,
+    krankheitFlags,
+    otherFlags,
+  ] = await Promise.all([
     VertretungRequestsFacade.listPending(),
     VertretungRequestsFacade.listPendingIndirect(),
     ChildrenFacade.list(),
+    SchoolAssistantsFacade.list(),
+    HandlungsbedarfFacade.listKrankheitFlags({ from, to }),
+    HandlungsbedarfFacade.listOtherFlags({ from, to }),
   ]);
 
   const requests = rawRequests.map((r) => ({
@@ -39,14 +61,67 @@ export default async function HandlungsbedarfPage() {
     lastName: c.lastName,
   }));
 
+  const schoolAssistantOptions = schoolAssistants
+    .filter((p) => !!p.userId)
+    .map((p) => ({ id: p.userId as string, name: p.name }));
+
+  // Narrow the facade's ProblemFlag[] back to each list's expected subset.
+  // The facade promises only krankheit kinds in listKrankheitFlags and only
+  // weitere kinds in listOtherFlags, but the return type is the full union.
+  const krankheit = krankheitFlags.filter(
+    (
+      f,
+    ): f is Extract<
+      typeof f,
+      {
+        kind:
+          | "SB_SICK_NO_SUBSTITUTE"
+          | "CHILD_ABSENT_BUT_WORK_BOOKED"
+          | "CHILD_ABSENT_INFO"
+          | "SUBSTITUTE_ALSO_SICK";
+      }
+    > =>
+      f.kind === "SB_SICK_NO_SUBSTITUTE" ||
+      f.kind === "CHILD_ABSENT_BUT_WORK_BOOKED" ||
+      f.kind === "CHILD_ABSENT_INFO" ||
+      f.kind === "SUBSTITUTE_ALSO_SICK",
+  );
+  const weitere = otherFlags.filter(
+    (
+      f,
+    ): f is Extract<
+      typeof f,
+      {
+        kind:
+          | "SCHEDULE_BLOCK_UNASSIGNED"
+          | "BOOKED_HOURS_OVER_SCHEDULE"
+          | "MISSING_SCHWEIGEPFLICHT";
+      }
+    > =>
+      f.kind === "SCHEDULE_BLOCK_UNASSIGNED" ||
+      f.kind === "BOOKED_HOURS_OVER_SCHEDULE" ||
+      f.kind === "MISSING_SCHWEIGEPFLICHT",
+  );
+
   return (
     <div className="space-y-8 p-6">
       <div>
         <h1 className="text-2xl font-semibold">Handlungsbedarf</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Anträge, die noch einem Kind zugeordnet werden müssen.
+          Übersicht über problematische Fälle der nächsten 7 Tage.
         </p>
       </div>
+
+      <PageSection title={`Krankheitsfälle (${krankheit.length})`}>
+        <SickFlagsList
+          flags={krankheit}
+          schoolAssistantOptions={schoolAssistantOptions}
+        />
+      </PageSection>
+
+      <PageSection title={`Weitere Fälle (${weitere.length})`}>
+        <OtherFlagsList flags={weitere} />
+      </PageSection>
 
       <PageSection title={`Vertretungs-Anträge (${requests.length})`}>
         <PendingRequestsTable

--- a/src/app/admin/handlungsbedarf/page.tsx
+++ b/src/app/admin/handlungsbedarf/page.tsx
@@ -2,13 +2,15 @@ import { requireAdmin } from "@/lib/auth-guards";
 import { VertretungRequestsFacade } from "@/features/vertretung-requests";
 import { ChildrenFacade } from "@/features/children";
 import { PendingRequestsTable } from "@/features/vertretung-requests/components/pending-requests-table";
+import { PendingIndirectRequestsTable } from "@/features/vertretung-requests/components/pending-indirect-requests-table";
 import { PageSection } from "@/components/page-section";
 
 export default async function HandlungsbedarfPage() {
   await requireAdmin();
 
-  const [rawRequests, children] = await Promise.all([
+  const [rawRequests, rawIndirectRequests, children] = await Promise.all([
     VertretungRequestsFacade.listPending(),
+    VertretungRequestsFacade.listPendingIndirect(),
     ChildrenFacade.list(),
   ]);
 
@@ -18,6 +20,16 @@ export default async function HandlungsbedarfPage() {
     date: r.date.toISOString().slice(0, 10),
     startTime: r.startTime,
     endTime: r.endTime,
+    substituteUser: r.substituteUser,
+  }));
+
+  const indirectRequests = rawIndirectRequests.map((r) => ({
+    id: r.id,
+    childNameText: r.childNameText,
+    date: r.date.toISOString().slice(0, 10),
+    startTime: r.startTime,
+    endTime: r.endTime,
+    note: r.note,
     substituteUser: r.substituteUser,
   }));
 
@@ -32,13 +44,20 @@ export default async function HandlungsbedarfPage() {
       <div>
         <h1 className="text-2xl font-semibold">Handlungsbedarf</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Vertretungs-Anträge, die noch einem Kind zugeordnet werden müssen.
+          Anträge, die noch einem Kind zugeordnet werden müssen.
         </p>
       </div>
 
-      <PageSection title={`Zuzuordnen (${requests.length})`}>
+      <PageSection title={`Vertretungs-Anträge (${requests.length})`}>
         <PendingRequestsTable
           requests={requests}
+          childOptions={childOptions}
+        />
+      </PageSection>
+
+      <PageSection title={`Indirekte Leistungen (${indirectRequests.length})`}>
+        <PendingIndirectRequestsTable
+          requests={indirectRequests}
           childOptions={childOptions}
         />
       </PageSection>

--- a/src/features/children/components/children-table.tsx
+++ b/src/features/children/components/children-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -40,11 +41,45 @@ export function ChildrenTable({
   schoolAssistantOptions,
   schoolOptions,
 }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
   const [wizardOpen, setWizardOpen] = useState(false);
-  const [openChildId, setOpenChildId] = useState<string | null>(null);
-  const [openTab, setOpenTab] = useState<"general" | "history" | "calendar">(
-    "general",
+  const [openChildId, setOpenChildId] = useState<string | null>(
+    searchParams.get("childId"),
   );
+  const [openTab, setOpenTab] = useState<"general" | "history" | "calendar">(
+    () => {
+      const t = searchParams.get("tab");
+      return t === "history" || t === "calendar" ? t : "general";
+    },
+  );
+
+  // Keep the URL in sync with deep-links from other admin pages
+  // (e.g. /admin/handlungsbedarf flags). Without this, navigating to
+  // /admin/children?childId=…&tab=calendar a second time would not re-open
+  // the sheet because state was already initialized.
+  useEffect(() => {
+    const urlChildId = searchParams.get("childId");
+    const urlTab = searchParams.get("tab");
+    if (urlChildId && urlChildId !== openChildId) setOpenChildId(urlChildId);
+    if (
+      (urlTab === "history" || urlTab === "calendar" || urlTab === "general") &&
+      urlTab !== openTab
+    ) {
+      setOpenTab(urlTab);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  // Strip the query params when the sheet is closed so a refresh doesn't
+  // re-open it. `replace` (not `push`) keeps the back button clean.
+  const clearDeepLink = () => {
+    if (searchParams.has("childId") || searchParams.has("tab")) {
+      router.replace(pathname);
+    }
+  };
   const [extraOptions, setExtraOptions] = useState<CostBearerOption[]>([]);
   const [extraSchoolOptions, setExtraSchoolOptions] = useState<SchoolOption[]>(
     [],
@@ -219,7 +254,12 @@ export function ChildrenTable({
       <ChildDetailSheet
         child={openChild}
         open={!!openChild}
-        onOpenChange={(next) => !next && setOpenChildId(null)}
+        onOpenChange={(next) => {
+          if (!next) {
+            setOpenChildId(null);
+            clearDeepLink();
+          }
+        }}
         tab={openTab}
         onTabChange={setOpenTab}
         costBearerOptions={allCostBearerOptions}

--- a/src/features/handlungsbedarf/components/other-flags-list.tsx
+++ b/src/features/handlungsbedarf/components/other-flags-list.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import Link from "next/link";
+import { CalendarClock, FileWarning, ShieldAlert } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ProblemFlag } from "../schemas";
+
+type OtherFlag = Extract<
+  ProblemFlag,
+  {
+    kind:
+      | "SCHEDULE_BLOCK_UNASSIGNED"
+      | "BOOKED_HOURS_OVER_SCHEDULE"
+      | "MISSING_SCHWEIGEPFLICHT";
+  }
+>;
+
+type Props = { flags: OtherFlag[] };
+
+function formatGermanDate(iso: string): string {
+  const [y, m, d] = iso.split("-");
+  return `${d}.${m}.${y}`;
+}
+
+function formatMinutes(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  if (h === 0) return `${m} min`;
+  if (m === 0) return `${h} h`;
+  return `${h} h ${m} min`;
+}
+
+export function OtherFlagsList({ flags }: Props) {
+  if (flags.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-6 text-center">
+        Keine weiteren problematischen Fälle.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y">
+      {flags.map((flag, i) => (
+        <li key={`${flag.kind}-${i}`}>
+          <FlagRowWrapper flag={flag}>
+            <FlagRow flag={flag} />
+          </FlagRowWrapper>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Wrappt die ganze Zeile in einen Link, wenn der Flag-Typ einen direkten
+ * Navigationsziel hat. Sonst nur ein neutraler Container mit Padding.
+ */
+function FlagRowWrapper({
+  flag,
+  children,
+}: {
+  flag: OtherFlag;
+  children: React.ReactNode;
+}) {
+  if (flag.kind === "SCHEDULE_BLOCK_UNASSIGNED") {
+    return (
+      <Link
+        href={`/admin/children?childId=${encodeURIComponent(flag.childId)}&tab=calendar`}
+        className="block p-3 transition-colors hover:bg-muted/50 sm:p-4"
+      >
+        {children}
+      </Link>
+    );
+  }
+  return <div className="p-3 sm:p-4">{children}</div>;
+}
+
+function FlagRow({ flag }: { flag: OtherFlag }) {
+  return (
+    <div className="flex min-w-0 items-start gap-3">
+      <FlagIcon kind={flag.kind} />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="font-medium">{flag.childName}</span>
+          {flag.kind !== "MISSING_SCHWEIGEPFLICHT" ? (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {formatGermanDate(flag.date)}
+            </span>
+          ) : null}
+          <SeverityBadge kind={flag.kind} />
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          <FlagHint flag={flag} />
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function FlagIcon({ kind }: { kind: OtherFlag["kind"] }) {
+  const Icon =
+    kind === "SCHEDULE_BLOCK_UNASSIGNED"
+      ? CalendarClock
+      : kind === "BOOKED_HOURS_OVER_SCHEDULE"
+        ? FileWarning
+        : ShieldAlert;
+  const colorClass =
+    kind === "MISSING_SCHWEIGEPFLICHT"
+      ? "text-red-500"
+      : kind === "BOOKED_HOURS_OVER_SCHEDULE"
+        ? "text-amber-500"
+        : "text-muted-foreground";
+  return <Icon className={cn("mt-0.5 size-5 shrink-0", colorClass)} />;
+}
+
+function SeverityBadge({ kind }: { kind: OtherFlag["kind"] }) {
+  const { label, classes } =
+    kind === "SCHEDULE_BLOCK_UNASSIGNED"
+      ? {
+          label: "Stundenplan ohne SB",
+          classes:
+            "bg-muted/40 text-muted-foreground border-muted-foreground/30",
+        }
+      : kind === "BOOKED_HOURS_OVER_SCHEDULE"
+        ? {
+            label: "Über Stundenplan",
+            classes:
+              "bg-amber-500/15 text-amber-900 dark:text-amber-200 border-amber-500/30",
+          }
+        : {
+            label: "Schweigepflicht fehlt",
+            classes:
+              "bg-red-500/15 text-red-900 dark:text-red-200 border-red-500/30",
+          };
+  return (
+    <span
+      className={cn(
+        "rounded-full border px-2 py-0.5 text-[10px] font-medium",
+        classes,
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function FlagHint({ flag }: { flag: OtherFlag }) {
+  switch (flag.kind) {
+    case "SCHEDULE_BLOCK_UNASSIGNED":
+      return (
+        <>
+          Stundenplan-Block {flag.startTime}–{flag.endTime}, kein Schulbegleiter
+          zugewiesen und keine Vertretung eingetragen.
+        </>
+      );
+    case "BOOKED_HOURS_OVER_SCHEDULE":
+      return (
+        <>
+          {formatMinutes(flag.bookedMinutes)} gebucht, Stundenplan sieht{" "}
+          {formatMinutes(flag.scheduledMinutes)} vor (Differenz{" "}
+          {formatMinutes(flag.bookedMinutes - flag.scheduledMinutes)}).
+        </>
+      );
+    case "MISSING_SCHWEIGEPFLICHT":
+      return <>Schweigepflichtsentbindung liegt noch nicht vor.</>;
+  }
+}

--- a/src/features/handlungsbedarf/components/sick-flags-list.tsx
+++ b/src/features/handlungsbedarf/components/sick-flags-list.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  AlertTriangle,
+  CalendarOff,
+  Info,
+  Stethoscope,
+  UserCheck,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  createVertretungAction,
+  deleteWorkEventAsAdminAction,
+} from "@/features/children/actions";
+import {
+  SchoolAssistantCombobox,
+  type SchoolAssistantOption,
+} from "@/features/children/components/calendar/school-assistant-combobox";
+import type { ProblemFlag } from "../schemas";
+
+/**
+ * Krankheit-related subset of ProblemFlag — all four kinds carry a `date` and a
+ * `childName`, which the row layout relies on.
+ */
+type KrankheitFlag = Extract<
+  ProblemFlag,
+  {
+    kind:
+      | "SB_SICK_NO_SUBSTITUTE"
+      | "CHILD_ABSENT_BUT_WORK_BOOKED"
+      | "CHILD_ABSENT_INFO"
+      | "SUBSTITUTE_ALSO_SICK";
+  }
+>;
+
+type Props = {
+  flags: KrankheitFlag[];
+  schoolAssistantOptions: SchoolAssistantOption[];
+};
+
+function formatGermanDate(iso: string): string {
+  const [y, m, d] = iso.split("-");
+  return `${d}.${m}.${y}`;
+}
+
+export function SickFlagsList({ flags, schoolAssistantOptions }: Props) {
+  if (flags.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-6 text-center">
+        Keine offenen Krankheitsfälle in den nächsten 7 Tagen.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y">
+      {flags.map((flag, i) => (
+        <li
+          key={`${flag.kind}-${i}`}
+          className="p-3 sm:p-4"
+        >
+          <FlagRow
+            flag={flag}
+            schoolAssistantOptions={schoolAssistantOptions}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function FlagRow({
+  flag,
+  schoolAssistantOptions,
+}: {
+  flag: KrankheitFlag;
+  schoolAssistantOptions: SchoolAssistantOption[];
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+      <div className="flex min-w-0 items-start gap-3">
+        <FlagIcon kind={flag.kind} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="font-medium">{flag.childName}</span>
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {formatGermanDate(flag.date)}
+            </span>
+            <SeverityBadge kind={flag.kind} />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            <FlagHint flag={flag} />
+          </p>
+        </div>
+      </div>
+      <div className="sm:shrink-0">
+        <QuickAction
+          flag={flag}
+          schoolAssistantOptions={schoolAssistantOptions}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FlagIcon({ kind }: { kind: KrankheitFlag["kind"] }) {
+  const Icon =
+    kind === "SB_SICK_NO_SUBSTITUTE" || kind === "SUBSTITUTE_ALSO_SICK"
+      ? AlertTriangle
+      : kind === "CHILD_ABSENT_BUT_WORK_BOOKED"
+        ? CalendarOff
+        : Info;
+  const colorClass =
+    kind === "SB_SICK_NO_SUBSTITUTE" || kind === "SUBSTITUTE_ALSO_SICK"
+      ? "text-red-500"
+      : kind === "CHILD_ABSENT_BUT_WORK_BOOKED"
+        ? "text-amber-500"
+        : "text-muted-foreground";
+  return <Icon className={cn("mt-0.5 size-5 shrink-0", colorClass)} />;
+}
+
+function SeverityBadge({ kind }: { kind: KrankheitFlag["kind"] }) {
+  const { label, classes } =
+    kind === "SB_SICK_NO_SUBSTITUTE"
+      ? {
+          label: "Vertretung fehlt",
+          classes:
+            "bg-red-500/15 text-red-900 dark:text-red-200 border-red-500/30",
+        }
+      : kind === "SUBSTITUTE_ALSO_SICK"
+        ? {
+            label: "Vertreter krank",
+            classes:
+              "bg-red-500/15 text-red-900 dark:text-red-200 border-red-500/30",
+          }
+        : kind === "CHILD_ABSENT_BUT_WORK_BOOKED"
+          ? {
+              label: "WORK trotz Krankheit",
+              classes:
+                "bg-amber-500/15 text-amber-900 dark:text-amber-200 border-amber-500/30",
+            }
+          : {
+              label: "Info",
+              classes:
+                "bg-muted/40 text-muted-foreground border-muted-foreground/30",
+            };
+  return (
+    <span
+      className={cn(
+        "rounded-full border px-2 py-0.5 text-[10px] font-medium",
+        classes,
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function FlagHint({ flag }: { flag: KrankheitFlag }) {
+  switch (flag.kind) {
+    case "SB_SICK_NO_SUBSTITUTE":
+      return (
+        <>
+          Schulbegleiter <strong>{flag.sbName}</strong> ist krank — noch keine
+          Vertretung eingetragen.
+        </>
+      );
+    case "SUBSTITUTE_ALSO_SICK":
+      return (
+        <>
+          Vertretung durch <strong>{flag.substituteName}</strong>, der/die
+          selbst am gleichen Tag krank ist.
+        </>
+      );
+    case "CHILD_ABSENT_BUT_WORK_BOOKED":
+      return (
+        <>
+          Kind ist als krank markiert, aber <strong>{flag.workUserName}</strong>{" "}
+          hat{" "}
+          {flag.workStart && flag.workEnd
+            ? `${flag.workStart}–${flag.workEnd}`
+            : "WORK"}{" "}
+          gebucht.
+          {flag.absenceNote ? (
+            <> Notiz: &bdquo;{flag.absenceNote}&ldquo;.</>
+          ) : null}
+        </>
+      );
+    case "CHILD_ABSENT_INFO":
+      return (
+        <>
+          Kind ist krank gemeldet.
+          {flag.absenceNote ? (
+            <> Notiz: &bdquo;{flag.absenceNote}&ldquo;.</>
+          ) : null}
+        </>
+      );
+  }
+}
+
+function QuickAction({
+  flag,
+  schoolAssistantOptions,
+}: {
+  flag: KrankheitFlag;
+  schoolAssistantOptions: SchoolAssistantOption[];
+}) {
+  if (
+    flag.kind === "SB_SICK_NO_SUBSTITUTE" ||
+    flag.kind === "SUBSTITUTE_ALSO_SICK"
+  ) {
+    return (
+      <VertretungQuickAction
+        childId={flag.childId}
+        date={flag.date}
+        schoolAssistantOptions={schoolAssistantOptions}
+      />
+    );
+  }
+  if (flag.kind === "CHILD_ABSENT_BUT_WORK_BOOKED") {
+    return <DeleteWorkQuickAction workEventId={flag.workEventId} />;
+  }
+  return null;
+}
+
+function VertretungQuickAction({
+  childId,
+  date,
+  schoolAssistantOptions,
+}: {
+  childId: string;
+  date: string;
+  schoolAssistantOptions: SchoolAssistantOption[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [substituteUserId, setSubstituteUserId] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const handleSave = () => {
+    if (!substituteUserId) return;
+    startTransition(async () => {
+      try {
+        await createVertretungAction({ childId, substituteUserId, date });
+        toast.success("Vertretung eingetragen.");
+        setOpen(false);
+        setSubstituteUserId(null);
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Speichern fehlgeschlagen.",
+        );
+      }
+    });
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setSubstituteUserId(null);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          size="sm"
+          className="w-full sm:w-auto"
+        >
+          <UserCheck className="size-3.5" /> Vertretung eintragen
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-72 p-3"
+      >
+        <div className="flex flex-col gap-2 text-sm">
+          <div className="text-xs font-medium">Vertretung eintragen</div>
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs text-muted-foreground">Vertreter</Label>
+            <SchoolAssistantCombobox
+              options={schoolAssistantOptions}
+              value={substituteUserId}
+              onChange={setSubstituteUserId}
+              placeholder="Wer vertritt?"
+            />
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Zeit wird vom Stundenplan übernommen.
+          </p>
+          <div className="flex justify-end gap-2 pt-1">
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSave}
+              disabled={!substituteUserId || pending}
+            >
+              {pending ? "Speichert…" : "Anlegen"}
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function DeleteWorkQuickAction({ workEventId }: { workEventId: string }) {
+  const [pending, startTransition] = useTransition();
+
+  const handleDelete = () => {
+    if (!confirm("WORK-Eintrag wirklich löschen?")) return;
+    startTransition(async () => {
+      try {
+        await deleteWorkEventAsAdminAction(workEventId);
+        toast.success("WORK-Eintrag gelöscht.");
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Löschen fehlgeschlagen.",
+        );
+      }
+    });
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="destructive"
+      className="w-full sm:w-auto"
+      onClick={handleDelete}
+      disabled={pending}
+    >
+      <Stethoscope className="size-3.5" /> WORK löschen
+    </Button>
+  );
+}

--- a/src/features/handlungsbedarf/facade.ts
+++ b/src/features/handlungsbedarf/facade.ts
@@ -1,0 +1,343 @@
+import {
+  findAllAssignments,
+  findAllSchedulesWithHolidayPlan,
+  findAssignmentsByUserIds,
+  findChildAbsencesInRange,
+  findChildrenMissingSchweigepflicht,
+  findChildWorkEventsInRange,
+  findSickEventsInRange,
+  findVertretungenInRange,
+  findWorkEventsForChildrenOnDates,
+} from "./services";
+import type {
+  BookedHoursOverScheduleFlag,
+  ChildAbsentInfoFlag,
+  ChildAbsentWorkBookedFlag,
+  MissingSchweigepflichtFlag,
+  ProblemFlag,
+  SbSickNoSubstituteFlag,
+  ScheduleBlockUnassignedFlag,
+  SubstituteAlsoSickFlag,
+} from "./schemas";
+
+// Tolerance applied to BOOKED_HOURS_OVER_SCHEDULE: only flag when daily booked
+// minutes exceed scheduled minutes by more than this. Covers the routine
+// vor-/nachviertelstunde without spamming the queue.
+const BOOKED_OVER_SCHEDULE_TOLERANCE_MIN = 30;
+
+function utcDateOnly(d: Date): Date {
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// ChildAssignment.weekday: Monday=0..Sunday=6.
+function isoWeekday(d: Date): number {
+  return (d.getUTCDay() + 6) % 7;
+}
+
+function timeToMin(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function enumerateDates(from: Date, to: Date): Date[] {
+  const out: Date[] = [];
+  const cur = new Date(from.getTime());
+  while (cur.getTime() <= to.getTime()) {
+    out.push(new Date(cur.getTime()));
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return out;
+}
+
+function isInHoliday(
+  date: Date,
+  ranges: { startDate: Date; endDate: Date }[],
+): boolean {
+  for (const r of ranges) {
+    if (
+      date.getTime() >= r.startDate.getTime() &&
+      date.getTime() <= r.endDate.getTime()
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const sortByDateName = <T extends { date: string; childName: string }>(
+  arr: T[],
+): T[] =>
+  arr.sort(
+    (a, b) =>
+      a.date.localeCompare(b.date) || a.childName.localeCompare(b.childName),
+  );
+
+export const HandlungsbedarfFacade = {
+  /**
+   * Krankheits-Flags im [from, to]-Fenster (inklusive Endpunkt). Decken die
+   * Top-Section auf /admin/handlungsbedarf ab.
+   */
+  async listKrankheitFlags({
+    from,
+    to,
+  }: {
+    from: Date;
+    to: Date;
+  }): Promise<ProblemFlag[]> {
+    const f = utcDateOnly(from);
+    const t = utcDateOnly(to);
+
+    const [sickEvents, absences, vertretungen] = await Promise.all([
+      findSickEventsInRange(f, t),
+      findChildAbsencesInRange(f, t),
+      findVertretungenInRange(f, t),
+    ]);
+
+    const sickUserIds = Array.from(new Set(sickEvents.map((e) => e.userId)));
+    const [assignments, conflictingWork] = await Promise.all([
+      findAssignmentsByUserIds(sickUserIds),
+      findWorkEventsForChildrenOnDates(
+        absences.map((a) => ({ childId: a.childId, date: a.date })),
+      ),
+    ]);
+
+    const coverageKey = new Set(
+      vertretungen.map((v) => `${v.childId}|${isoDate(v.date)}`),
+    );
+
+    const assignmentsByUser = new Map<string, typeof assignments>();
+    for (const a of assignments) {
+      const arr = assignmentsByUser.get(a.userId) ?? [];
+      arr.push(a);
+      assignmentsByUser.set(a.userId, arr);
+    }
+
+    const sbSickFlags: SbSickNoSubstituteFlag[] = [];
+    for (const ev of sickEvents) {
+      const weekday = isoWeekday(ev.date);
+      const dayAssignments =
+        assignmentsByUser
+          .get(ev.userId)
+          ?.filter((a) => a.weekday === weekday) ?? [];
+
+      // Tandem produces two assignment rows for the same (user, weekday, child);
+      // collapse to one flag per child.
+      const seen = new Set<string>();
+      for (const a of dayAssignments) {
+        if (seen.has(a.child.id)) continue;
+        seen.add(a.child.id);
+        if (coverageKey.has(`${a.child.id}|${isoDate(ev.date)}`)) continue;
+        sbSickFlags.push({
+          kind: "SB_SICK_NO_SUBSTITUTE",
+          date: isoDate(ev.date),
+          sbUserId: ev.userId,
+          sbName: ev.user.name,
+          childId: a.child.id,
+          childName: `${a.child.firstName} ${a.child.lastName}`,
+        });
+      }
+    }
+
+    const workByKey = new Map<string, typeof conflictingWork>();
+    for (const w of conflictingWork) {
+      const k = `${w.childId}|${isoDate(w.date)}`;
+      const arr = workByKey.get(k) ?? [];
+      arr.push(w);
+      workByKey.set(k, arr);
+    }
+
+    const conflictFlags: ChildAbsentWorkBookedFlag[] = [];
+    const infoFlags: ChildAbsentInfoFlag[] = [];
+    for (const ab of absences) {
+      const key = `${ab.childId}|${isoDate(ab.date)}`;
+      const conflicts = workByKey.get(key) ?? [];
+      const childName = `${ab.child.firstName} ${ab.child.lastName}`;
+      if (conflicts.length > 0) {
+        for (const w of conflicts) {
+          conflictFlags.push({
+            kind: "CHILD_ABSENT_BUT_WORK_BOOKED",
+            date: isoDate(ab.date),
+            childId: ab.childId,
+            childName,
+            workEventId: w.id,
+            workUserId: w.userId,
+            workUserName: w.user.name,
+            workStart: w.startTime,
+            workEnd: w.endTime,
+            absenceNote: ab.note,
+          });
+        }
+      } else {
+        infoFlags.push({
+          kind: "CHILD_ABSENT_INFO",
+          date: isoDate(ab.date),
+          childId: ab.childId,
+          childName,
+          absenceNote: ab.note,
+        });
+      }
+    }
+
+    // SUBSTITUTE_ALSO_SICK: ChildVertretung weist auf einen Vertreter, der am
+    // gleichen Datum selbst SICK ist.
+    const sickKey = new Set(
+      sickEvents.map((e) => `${e.userId}|${isoDate(e.date)}`),
+    );
+    const substituteSickFlags: SubstituteAlsoSickFlag[] = [];
+    const seenSubstitutePair = new Set<string>();
+    for (const v of vertretungen) {
+      const pairKey = `${v.childId}|${isoDate(v.date)}|${v.substituteUserId}`;
+      if (seenSubstitutePair.has(pairKey)) continue;
+      if (!sickKey.has(`${v.substituteUserId}|${isoDate(v.date)}`)) continue;
+      seenSubstitutePair.add(pairKey);
+      substituteSickFlags.push({
+        kind: "SUBSTITUTE_ALSO_SICK",
+        date: isoDate(v.date),
+        childId: v.childId,
+        childName: `${v.child.firstName} ${v.child.lastName}`,
+        substituteUserId: v.substituteUserId,
+        substituteName: v.substituteUser.name,
+      });
+    }
+
+    return [
+      ...sortByDateName(sbSickFlags),
+      ...sortByDateName(substituteSickFlags),
+      ...sortByDateName(conflictFlags),
+      ...sortByDateName(infoFlags),
+    ];
+  },
+
+  /**
+   * Restliche problematische Fälle im Fenster (Stundenplan ohne SB, gebuchte
+   * Stunden > Stundenplan) + statische Flags wie fehlende Schweigepflicht
+   * (date-unabhängig, deshalb ohne Window-Bezug).
+   */
+  async listOtherFlags({
+    from,
+    to,
+  }: {
+    from: Date;
+    to: Date;
+  }): Promise<ProblemFlag[]> {
+    const f = utcDateOnly(from);
+    const t = utcDateOnly(to);
+
+    const [schedules, assignments, vertretungen, workEvents, missingSchweige] =
+      await Promise.all([
+        findAllSchedulesWithHolidayPlan(),
+        findAllAssignments(),
+        findVertretungenInRange(f, t),
+        findChildWorkEventsInRange(f, t),
+        findChildrenMissingSchweigepflicht(),
+      ]);
+
+    const dates = enumerateDates(f, t);
+
+    // assignedKey = `${childId}|${weekday}` for any (child, weekday) that has
+    // at least one regular assignment.
+    const assignedKey = new Set<string>();
+    for (const a of assignments) {
+      assignedKey.add(`${a.childId}|${a.weekday}`);
+    }
+    // covered (by Vertretung) for the day.
+    const vertretungKey = new Set(
+      vertretungen.map((v) => `${v.childId}|${isoDate(v.date)}`),
+    );
+
+    // Holiday ranges per child (collected from the school's HolidayPlan).
+    const holidayRangesByChild = new Map<
+      string,
+      { startDate: Date; endDate: Date }[]
+    >();
+    for (const s of schedules) {
+      if (holidayRangesByChild.has(s.childId)) continue;
+      const ranges = s.child.school?.holidayPlan?.holidays ?? [];
+      holidayRangesByChild.set(s.childId, ranges);
+    }
+
+    // SCHEDULE_BLOCK_UNASSIGNED
+    const scheduleUnassignedFlags: ScheduleBlockUnassignedFlag[] = [];
+    for (const s of schedules) {
+      const childName = `${s.child.firstName} ${s.child.lastName}`;
+      const ranges = holidayRangesByChild.get(s.childId) ?? [];
+      for (const d of dates) {
+        if (isoWeekday(d) !== s.weekday) continue;
+        if (isInHoliday(d, ranges)) continue;
+        if (assignedKey.has(`${s.childId}|${s.weekday}`)) continue;
+        if (vertretungKey.has(`${s.childId}|${isoDate(d)}`)) continue;
+        scheduleUnassignedFlags.push({
+          kind: "SCHEDULE_BLOCK_UNASSIGNED",
+          date: isoDate(d),
+          childId: s.childId,
+          childName,
+          startTime: s.startTime,
+          endTime: s.endTime,
+        });
+      }
+    }
+
+    // BOOKED_HOURS_OVER_SCHEDULE
+    // Sum scheduled minutes per (childId, weekday).
+    const scheduledMinutesByChildWeekday = new Map<string, number>();
+    const childNameById = new Map<string, string>();
+    for (const s of schedules) {
+      const key = `${s.childId}|${s.weekday}`;
+      const min =
+        (scheduledMinutesByChildWeekday.get(key) ?? 0) +
+        (timeToMin(s.endTime) - timeToMin(s.startTime));
+      scheduledMinutesByChildWeekday.set(key, min);
+      childNameById.set(s.childId, `${s.child.firstName} ${s.child.lastName}`);
+    }
+
+    // Sum booked WORK minutes per (childId, date). Events without explicit
+    // times can't contribute to a duration comparison, so they're skipped.
+    const bookedMinutesByPair = new Map<string, number>();
+    for (const w of workEvents) {
+      if (!w.childId || !w.startTime || !w.endTime) continue;
+      const key = `${w.childId}|${isoDate(w.date)}`;
+      const min =
+        (bookedMinutesByPair.get(key) ?? 0) +
+        (timeToMin(w.endTime) - timeToMin(w.startTime));
+      bookedMinutesByPair.set(key, min);
+    }
+
+    const overScheduleFlags: BookedHoursOverScheduleFlag[] = [];
+    for (const [key, booked] of bookedMinutesByPair) {
+      const [childId, dateIso] = key.split("|");
+      const weekday = isoWeekday(new Date(`${dateIso}T00:00:00Z`));
+      const scheduled =
+        scheduledMinutesByChildWeekday.get(`${childId}|${weekday}`) ?? 0;
+      if (booked - scheduled <= BOOKED_OVER_SCHEDULE_TOLERANCE_MIN) continue;
+      overScheduleFlags.push({
+        kind: "BOOKED_HOURS_OVER_SCHEDULE",
+        date: dateIso,
+        childId,
+        childName: childNameById.get(childId) ?? childId,
+        bookedMinutes: booked,
+        scheduledMinutes: scheduled,
+      });
+    }
+
+    // MISSING_SCHWEIGEPFLICHT (static, no date)
+    const missingSchweigeFlags: MissingSchweigepflichtFlag[] = missingSchweige
+      .map((c) => ({
+        kind: "MISSING_SCHWEIGEPFLICHT" as const,
+        childId: c.id,
+        childName: `${c.firstName} ${c.lastName}`,
+      }))
+      .sort((a, b) => a.childName.localeCompare(b.childName));
+
+    return [
+      ...sortByDateName(scheduleUnassignedFlags),
+      ...sortByDateName(overScheduleFlags),
+      ...missingSchweigeFlags,
+    ];
+  },
+};

--- a/src/features/handlungsbedarf/index.ts
+++ b/src/features/handlungsbedarf/index.ts
@@ -1,0 +1,2 @@
+export { HandlungsbedarfFacade } from "./facade";
+export type { ProblemFlag } from "./schemas";

--- a/src/features/handlungsbedarf/schemas.ts
+++ b/src/features/handlungsbedarf/schemas.ts
@@ -1,0 +1,101 @@
+export type ProblemFlag =
+  | SbSickNoSubstituteFlag
+  | ChildAbsentWorkBookedFlag
+  | ChildAbsentInfoFlag
+  | SubstituteAlsoSickFlag
+  | ScheduleBlockUnassignedFlag
+  | BookedHoursOverScheduleFlag
+  | MissingSchweigepflichtFlag;
+
+/**
+ * Krankheit: SB is sick on a date but one of their normally-assigned children
+ * has no ChildVertretung covering it.
+ */
+export type SbSickNoSubstituteFlag = {
+  kind: "SB_SICK_NO_SUBSTITUTE";
+  /** ISO YYYY-MM-DD */
+  date: string;
+  sbUserId: string;
+  sbName: string;
+  childId: string;
+  childName: string;
+};
+
+/**
+ * Krankheit: child is marked absent but a WORK event was still booked for them.
+ */
+export type ChildAbsentWorkBookedFlag = {
+  kind: "CHILD_ABSENT_BUT_WORK_BOOKED";
+  date: string;
+  childId: string;
+  childName: string;
+  workEventId: string;
+  workUserId: string;
+  workUserName: string;
+  workStart: string | null;
+  workEnd: string | null;
+  absenceNote: string | null;
+};
+
+/**
+ * Krankheit (info): child is absent, no WORK conflict — informational only.
+ */
+export type ChildAbsentInfoFlag = {
+  kind: "CHILD_ABSENT_INFO";
+  date: string;
+  childId: string;
+  childName: string;
+  absenceNote: string | null;
+};
+
+/**
+ * Krankheit: a ChildVertretung points at a substitute who is themselves SICK
+ * on that date — the substitute can't actually cover the slot.
+ */
+export type SubstituteAlsoSickFlag = {
+  kind: "SUBSTITUTE_ALSO_SICK";
+  date: string;
+  childId: string;
+  childName: string;
+  substituteUserId: string;
+  substituteName: string;
+};
+
+/**
+ * Weiterer Fall: a Schedule block exists on a weekday but no SB is on it for
+ * that date (no ChildAssignment + no covering ChildVertretung). School-holiday
+ * dates are excluded by the facade.
+ */
+export type ScheduleBlockUnassignedFlag = {
+  kind: "SCHEDULE_BLOCK_UNASSIGNED";
+  date: string;
+  childId: string;
+  childName: string;
+  startTime: string;
+  endTime: string;
+};
+
+/**
+ * Weiterer Fall: total daily WORK minutes booked for a child noticeably exceed
+ * the scheduled minutes for that weekday (tolerance: 30 min/day).
+ */
+export type BookedHoursOverScheduleFlag = {
+  kind: "BOOKED_HOURS_OVER_SCHEDULE";
+  date: string;
+  childId: string;
+  childName: string;
+  /** Summed WORK minutes for this (child, date) across all SBs. */
+  bookedMinutes: number;
+  /** Summed Schedule minutes for the child's weekday. */
+  scheduledMinutes: number;
+};
+
+/**
+ * Weiterer Fall: child is missing the Schweigepflichtsentbindung (boolean is
+ * still `false`). Static admin task — not date-bound. Surfaced once per child.
+ */
+export type MissingSchweigepflichtFlag = {
+  kind: "MISSING_SCHWEIGEPFLICHT";
+  childId: string;
+  childName: string;
+};

--- a/src/features/handlungsbedarf/services/index.ts
+++ b/src/features/handlungsbedarf/services/index.ts
@@ -1,0 +1,149 @@
+import { prisma } from "@/lib/prisma";
+import { EventType } from "@/generated/prisma";
+
+export async function findSickEventsInRange(from: Date, to: Date) {
+  return prisma.event.findMany({
+    where: {
+      type: EventType.SICK,
+      deleted: false,
+      date: { gte: from, lte: to },
+    },
+    select: {
+      id: true,
+      userId: true,
+      date: true,
+      user: { select: { id: true, name: true } },
+    },
+  });
+}
+
+export async function findAssignmentsByUserIds(userIds: string[]) {
+  if (userIds.length === 0) return [];
+  return prisma.childAssignment.findMany({
+    where: { userId: { in: userIds } },
+    select: {
+      userId: true,
+      weekday: true,
+      child: { select: { id: true, firstName: true, lastName: true } },
+    },
+  });
+}
+
+export async function findVertretungenInRange(from: Date, to: Date) {
+  return prisma.childVertretung.findMany({
+    where: { date: { gte: from, lte: to } },
+    select: {
+      childId: true,
+      date: true,
+      substituteUserId: true,
+      child: { select: { firstName: true, lastName: true } },
+      substituteUser: { select: { name: true } },
+    },
+  });
+}
+
+export async function findChildAbsencesInRange(from: Date, to: Date) {
+  return prisma.childAbsence.findMany({
+    where: { date: { gte: from, lte: to } },
+    select: {
+      childId: true,
+      date: true,
+      note: true,
+      child: { select: { firstName: true, lastName: true } },
+    },
+  });
+}
+
+export async function findWorkEventsForChildrenOnDates(
+  pairs: { childId: string; date: Date }[],
+) {
+  if (pairs.length === 0) return [];
+  return prisma.event.findMany({
+    where: {
+      type: EventType.WORK,
+      deleted: false,
+      OR: pairs.map((p) => ({ childId: p.childId, date: p.date })),
+    },
+    select: {
+      id: true,
+      childId: true,
+      date: true,
+      startTime: true,
+      endTime: true,
+      userId: true,
+      user: { select: { name: true } },
+    },
+  });
+}
+
+/**
+ * Schedule blocks across all children with the child's school holiday plan
+ * attached. Used to detect uncovered weekday slots (after subtracting holiday
+ * dates and existing assignments / Vertretungen).
+ */
+export async function findAllSchedulesWithHolidayPlan() {
+  return prisma.schedule.findMany({
+    select: {
+      childId: true,
+      weekday: true,
+      startTime: true,
+      endTime: true,
+      child: {
+        select: {
+          firstName: true,
+          lastName: true,
+          school: {
+            select: {
+              holidayPlan: {
+                select: {
+                  holidays: { select: { startDate: true, endDate: true } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+/** All child→user assignments (weekday-based). Used for unassigned-block detection. */
+export async function findAllAssignments() {
+  return prisma.childAssignment.findMany({
+    select: { childId: true, weekday: true, userId: true },
+  });
+}
+
+/**
+ * All WORK events touching a child in the range. Returned with startTime/endTime
+ * so the facade can sum daily minutes per (child, date) and compare against
+ * Schedule minutes.
+ */
+export async function findChildWorkEventsInRange(from: Date, to: Date) {
+  return prisma.event.findMany({
+    where: {
+      type: EventType.WORK,
+      deleted: false,
+      date: { gte: from, lte: to },
+      childId: { not: null },
+    },
+    select: {
+      childId: true,
+      date: true,
+      startTime: true,
+      endTime: true,
+    },
+  });
+}
+
+/**
+ * All children currently missing the Schweigepflichtsentbindung. Static — not
+ * date-bound.
+ */
+export async function findChildrenMissingSchweigepflicht() {
+  return prisma.child.findMany({
+    where: { schweigepflichtsentbindung: false },
+    select: { id: true, firstName: true, lastName: true },
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+  });
+}

--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -428,7 +428,7 @@ export function NewEntrySheet({
           })`,
         );
       } else {
-        await createIndirectEventByNameAction({
+        const result = await createIndirectEventByNameAction({
           childNameText: indirectChildName.trim(),
           date,
           startTime,
@@ -436,7 +436,13 @@ export function NewEntrySheet({
           note: note.trim(),
           signaturePngBase64: pngBase64,
         });
-        toast.success("Indirekte Leistung gespeichert");
+        if (result.status === "QUEUED") {
+          toast.success(
+            "Indirekte Leistung gespeichert — wird vom Admin dem Kind zugeordnet.",
+          );
+        } else {
+          toast.success("Indirekte Leistung gespeichert");
+        }
       }
       setSigOpen(false);
       onOpenChange(false);

--- a/src/features/vertretung-requests/actions.ts
+++ b/src/features/vertretung-requests/actions.ts
@@ -5,6 +5,7 @@ import { requireAuth, requireAdmin } from "@/lib/auth-guards";
 import { VertretungRequestsFacade } from "./facade";
 import type {
   CreateVertretungRequestInput,
+  ResolveIndirectRequestInput,
   ResolveVertretungRequestInput,
   VertretungPrefillLookupInput,
 } from "./schemas";
@@ -58,5 +59,20 @@ export async function deleteOwnVertretungRequestAction(id: string) {
 export async function deleteOwnVertretungAction(id: string) {
   const user = await requireAuth();
   await VertretungRequestsFacade.deleteOwnVertretung(id, user.id);
+  revalidateVertretungPaths();
+}
+
+export async function resolveIndirectRequestAction(
+  id: string,
+  input: ResolveIndirectRequestInput,
+) {
+  const admin = await requireAdmin();
+  await VertretungRequestsFacade.resolveIndirect(id, admin.id, input);
+  revalidateVertretungPaths();
+}
+
+export async function rejectIndirectRequestAction(id: string) {
+  const admin = await requireAdmin();
+  await VertretungRequestsFacade.reject(id, admin.id);
   revalidateVertretungPaths();
 }

--- a/src/features/vertretung-requests/components/pending-indirect-requests-table.tsx
+++ b/src/features/vertretung-requests/components/pending-indirect-requests-table.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Check, ChevronsUpDown, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import {
+  rejectIndirectRequestAction,
+  resolveIndirectRequestAction,
+} from "../actions";
+
+type ChildOption = { id: string; firstName: string; lastName: string };
+
+type Request = {
+  id: string;
+  childNameText: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  note: string | null;
+  substituteUser: { id: string; name: string; email: string };
+};
+
+type Props = {
+  requests: Request[];
+  childOptions: ChildOption[];
+};
+
+function ChildPicker({
+  childOptions,
+  value,
+  onChange,
+  defaultQuery,
+}: {
+  childOptions: ChildOption[];
+  value: string;
+  onChange: (id: string) => void;
+  defaultQuery: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = childOptions.find((c) => c.id === value);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          size="sm"
+          className="h-8 w-full justify-between font-normal"
+        >
+          <span className={cn(!selected && "text-muted-foreground")}>
+            {selected
+              ? `${selected.firstName} ${selected.lastName}`
+              : "Kind wählen…"}
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-(--radix-popover-trigger-width) min-w-(--radix-popover-trigger-width) p-0"
+        align="start"
+      >
+        <Command defaultValue={defaultQuery}>
+          <CommandInput placeholder="Vor- oder Nachname tippen…" />
+          <CommandList>
+            <CommandEmpty>Keine Treffer.</CommandEmpty>
+            <CommandGroup>
+              {childOptions.map((c) => (
+                <CommandItem
+                  key={c.id}
+                  value={`${c.firstName} ${c.lastName}`}
+                  onSelect={() => {
+                    onChange(c.id === value ? "" : c.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 size-4",
+                      value === c.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {c.firstName} {c.lastName}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function RequestRow({
+  request,
+  childOptions,
+}: {
+  request: Request;
+  childOptions: ChildOption[];
+}) {
+  const [selectedChildId, setSelectedChildId] = useState("");
+  const [pending, startTransition] = useTransition();
+
+  const handleResolve = () => {
+    if (!selectedChildId) return;
+    startTransition(async () => {
+      try {
+        await resolveIndirectRequestAction(request.id, {
+          childId: selectedChildId,
+        });
+        toast.success("Zuordnung gespeichert.");
+      } catch (e: unknown) {
+        toast.error(e instanceof Error ? e.message : "Fehler beim Speichern.");
+      }
+    });
+  };
+
+  const handleReject = () => {
+    startTransition(async () => {
+      try {
+        await rejectIndirectRequestAction(request.id);
+        toast.success("Antrag abgelehnt.");
+      } catch (e: unknown) {
+        toast.error(e instanceof Error ? e.message : "Fehler.");
+      }
+    });
+  };
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">
+        {request.substituteUser.name}
+      </TableCell>
+      <TableCell>{request.childNameText}</TableCell>
+      <TableCell className="tabular-nums">{request.date}</TableCell>
+      <TableCell className="tabular-nums">
+        {request.startTime}–{request.endTime}
+      </TableCell>
+      <TableCell className="max-w-xs text-sm text-muted-foreground">
+        {request.note ?? "—"}
+      </TableCell>
+      <TableCell className="min-w-48">
+        <ChildPicker
+          childOptions={childOptions}
+          value={selectedChildId}
+          onChange={setSelectedChildId}
+          defaultQuery={request.childNameText}
+        />
+      </TableCell>
+      <TableCell>
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            disabled={!selectedChildId || pending}
+            onClick={handleResolve}
+            className="h-8"
+          >
+            <Check className="size-3.5" /> Zuordnen
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={handleReject}
+            className="h-8 text-destructive hover:text-destructive"
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function PendingIndirectRequestsTable({
+  requests,
+  childOptions,
+}: Props) {
+  if (requests.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-6 text-center">
+        Keine offenen indirekten Leistungen.
+      </p>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Schulbegleiter</TableHead>
+          <TableHead>Eingegebener Name</TableHead>
+          <TableHead>Datum</TableHead>
+          <TableHead>Zeiten</TableHead>
+          <TableHead>Notiz</TableHead>
+          <TableHead>Kind zuordnen</TableHead>
+          <TableHead />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {requests.map((r) => (
+          <RequestRow
+            key={r.id}
+            request={r}
+            childOptions={childOptions}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -2,10 +2,14 @@ import { randomUUID } from "crypto";
 import { uploadSignaturePng } from "@/lib/storage";
 import { exactMatchChild } from "@/lib/child-matching";
 import {
+  CreateIndirectPendingRequestSchema,
   CreateVertretungRequestSchema,
+  ResolveIndirectRequestSchema,
   ResolveVertretungRequestSchema,
   VertretungPrefillLookupSchema,
+  type CreateIndirectPendingRequestInput,
   type CreateVertretungRequestInput,
+  type ResolveIndirectRequestInput,
   type ResolveVertretungRequestInput,
   type VertretungPrefillLookupInput,
   type VertretungPrefillResult,
@@ -22,13 +26,17 @@ import {
   findRequestById,
   getScheduleTimeBlocks,
   insertChildVertretungBlocks,
+  insertIndirectWorkEvent,
   insertVertretungWorkEvent,
   listPendingRequests,
   listRequestsForUser,
   rejectRequest,
   resolveRequest,
 } from "./services";
-import { PendingVertretungStatus } from "@/generated/prisma";
+import {
+  PendingRequestKind,
+  PendingVertretungStatus,
+} from "@/generated/prisma";
 
 export const VertretungRequestsFacade = {
   async create(substituteUserId: string, input: CreateVertretungRequestInput) {
@@ -259,5 +267,80 @@ export const VertretungRequestsFacade = {
       throw new Error("Dieser Antrag wurde bereits bearbeitet.");
     }
     return rejectRequest(id, adminUserId);
+  },
+
+  /**
+   * INDIRECT-Antrag, dessen Name nicht eindeutig einem Kind zugeordnet werden
+   * konnte: Signatur hochladen, Anfrage in die Admin-Queue stellen (PENDING).
+   * Caller (Use Case) hat den exactMatchChild-Check schon gemacht.
+   */
+  async createIndirectPending(
+    substituteUserId: string,
+    input: CreateIndirectPendingRequestInput,
+  ) {
+    const parsed = CreateIndirectPendingRequestSchema.parse(input);
+
+    const signatureKey = `signatures/indirect-requests/${randomUUID()}.png`;
+    await uploadSignaturePng(signatureKey, parsed.signaturePngBase64);
+
+    const date = parseIsoDate(parsed.date);
+    return createPendingVertretungRequest({
+      kind: PendingRequestKind.INDIRECT,
+      substituteUserId,
+      childNameText: parsed.childNameText,
+      date,
+      startTime: parsed.startTime,
+      endTime: parsed.endTime,
+      signatureKey,
+      note: parsed.note,
+      matchedChildId: null,
+      matchConfidence: null,
+      status: PendingVertretungStatus.PENDING,
+    });
+  },
+
+  async listPendingIndirect() {
+    return listPendingRequests(PendingRequestKind.INDIRECT);
+  },
+
+  async countPendingIndirect() {
+    return countPendingRequests(PendingRequestKind.INDIRECT);
+  },
+
+  /**
+   * Admin ordnet einen unentschiedenen INDIRECT-Antrag einem Kind zu. Erzeugt
+   * ein INDIRECT-Event (mit ursprünglicher Signatur, Zeiten, Notiz) und
+   * markiert die Anfrage als RESOLVED.
+   */
+  async resolveIndirect(
+    id: string,
+    adminUserId: string,
+    input: ResolveIndirectRequestInput,
+  ) {
+    const parsed = ResolveIndirectRequestSchema.parse(input);
+
+    const request = await findRequestById(id);
+    if (!request) throw new Error("Antrag nicht gefunden.");
+    if (request.kind !== PendingRequestKind.INDIRECT) {
+      throw new Error("Antrag ist keine indirekte Leistung.");
+    }
+    if (request.status !== PendingVertretungStatus.PENDING) {
+      throw new Error("Dieser Antrag wurde bereits bearbeitet.");
+    }
+    if (!request.note) {
+      throw new Error("Antrag enthält keine Notiz.");
+    }
+
+    await insertIndirectWorkEvent({
+      childId: parsed.childId,
+      userId: request.substituteUserId,
+      date: request.date,
+      startTime: request.startTime,
+      endTime: request.endTime,
+      signatureKey: request.signatureKey,
+      note: request.note,
+    });
+
+    return resolveRequest(id, parsed.childId, adminUserId);
   },
 };

--- a/src/features/vertretung-requests/schemas.ts
+++ b/src/features/vertretung-requests/schemas.ts
@@ -20,6 +20,27 @@ export type ResolveVertretungRequestInput = z.infer<
   typeof ResolveVertretungRequestSchema
 >;
 
+export const CreateIndirectPendingRequestSchema = z.object({
+  childNameText: z.string().min(2, "Name muss mindestens 2 Zeichen haben."),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Ungültiges Datum."),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/, "Ungültige Startzeit."),
+  endTime: z.string().regex(/^\d{2}:\d{2}$/, "Ungültige Endzeit."),
+  note: z.string().min(3, "Notiz ist Pflicht (mind. 3 Zeichen).").max(2000),
+  signaturePngBase64: z.string().min(1, "Unterschrift fehlt."),
+});
+
+export type CreateIndirectPendingRequestInput = z.infer<
+  typeof CreateIndirectPendingRequestSchema
+>;
+
+export const ResolveIndirectRequestSchema = z.object({
+  childId: z.string().min(1, "Kind muss ausgewählt werden."),
+});
+
+export type ResolveIndirectRequestInput = z.infer<
+  typeof ResolveIndirectRequestSchema
+>;
+
 export const VertretungPrefillLookupSchema = z.object({
   name: z.string(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Ungültiges Datum."),

--- a/src/features/vertretung-requests/services/index.ts
+++ b/src/features/vertretung-requests/services/index.ts
@@ -1,5 +1,9 @@
 import { prisma } from "@/lib/prisma";
-import { EventType, PendingVertretungStatus } from "@/generated/prisma";
+import {
+  EventType,
+  PendingRequestKind,
+  PendingVertretungStatus,
+} from "@/generated/prisma";
 
 export async function createPendingVertretungRequest(data: {
   substituteUserId: string;
@@ -11,13 +15,17 @@ export async function createPendingVertretungRequest(data: {
   matchedChildId: string | null;
   matchConfidence: number | null;
   status: PendingVertretungStatus;
+  kind?: PendingRequestKind;
+  note?: string | null;
 }) {
   return prisma.pendingVertretungRequest.create({ data });
 }
 
-export async function listPendingRequests() {
+export async function listPendingRequests(
+  kind: PendingRequestKind = PendingRequestKind.VERTRETUNG,
+) {
   return prisma.pendingVertretungRequest.findMany({
-    where: { status: PendingVertretungStatus.PENDING },
+    where: { status: PendingVertretungStatus.PENDING, kind },
     include: {
       substituteUser: { select: { id: true, name: true, email: true } },
     },
@@ -56,9 +64,35 @@ export async function rejectRequest(id: string, resolvedByUserId: string) {
   });
 }
 
-export async function countPendingRequests() {
+export async function countPendingRequests(
+  kind: PendingRequestKind = PendingRequestKind.VERTRETUNG,
+) {
   return prisma.pendingVertretungRequest.count({
-    where: { status: PendingVertretungStatus.PENDING },
+    where: { status: PendingVertretungStatus.PENDING, kind },
+  });
+}
+
+export async function insertIndirectWorkEvent(args: {
+  childId: string;
+  userId: string;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  signatureKey: string;
+  note: string;
+}) {
+  return prisma.event.create({
+    data: {
+      childId: args.childId,
+      userId: args.userId,
+      type: EventType.INDIRECT,
+      date: args.date,
+      startTime: args.startTime,
+      endTime: args.endTime,
+      signatureKey: args.signatureKey,
+      note: args.note,
+      deleted: false,
+    },
   });
 }
 
@@ -70,6 +104,7 @@ export async function listRequestsForUser(
   return prisma.pendingVertretungRequest.findMany({
     where: {
       substituteUserId,
+      kind: PendingRequestKind.VERTRETUNG,
       status: {
         in: [PendingVertretungStatus.PENDING, PendingVertretungStatus.RESOLVED],
       },

--- a/src/use-cases/create-indirect-event-by-name.ts
+++ b/src/use-cases/create-indirect-event-by-name.ts
@@ -2,12 +2,15 @@
  * Use case: Create an INDIRECT timesheet event from a free-text child name.
  *
  * Mirrors the Vertretung-style free-text UX: the SB types the child's name
- * and the server resolves it via exact match against the Child table. If no
- * exact match is found the request is rejected — there is no admin queue for
- * indirect entries (decision: 2026-06-17).
+ * and the server resolves it via exact match against the Child table.
+ *  - Exakter Match → INDIRECT-Event wird direkt erstellt (createTimesheetEvent).
+ *  - Kein Match → Antrag landet als PENDING in der Admin-Queue
+ *    (PendingVertretungRequest mit kind=INDIRECT). Admin ordnet das Kind
+ *    nachträglich zu, das Event wird beim Resolve erzeugt.
  *
- * The resolved childId is then handed to the existing createTimesheetEvent
- * use case which performs the cross-feature validation and insert.
+ * Diese „Queue statt Fehler" Strategie ersetzt die ursprüngliche Entscheidung
+ * vom 2026-06-17 (damals: Fehler anzeigen), weil die SB sonst bei einer
+ * Schreibweisen-Variation des Kindesnamens den Eintrag nicht speichern konnte.
  */
 
 import { exactMatchChild } from "@/lib/child-matching";
@@ -15,28 +18,41 @@ import {
   CreateIndirectByNameSchema,
   type CreateIndirectByNameInput,
 } from "@/features/timesheet/schemas";
+import { VertretungRequestsFacade } from "@/features/vertretung-requests";
 import { createTimesheetEvent } from "./create-timesheet-event";
+
+export type CreateIndirectByNameResult =
+  | { status: "CREATED" }
+  | { status: "QUEUED"; requestId: string };
 
 export async function createIndirectEventByName(
   userId: string,
   input: CreateIndirectByNameInput,
-) {
+): Promise<CreateIndirectByNameResult> {
   const parsed = CreateIndirectByNameSchema.parse(input);
 
   const match = await exactMatchChild(parsed.childNameText);
-  if (!match) {
-    throw new Error(
-      `Kein Kind mit dem Namen „${parsed.childNameText.trim()}" gefunden.`,
-    );
+
+  if (match) {
+    await createTimesheetEvent(userId, {
+      type: "INDIRECT",
+      date: parsed.date,
+      childIds: [match.childId],
+      startTime: parsed.startTime,
+      endTime: parsed.endTime,
+      note: parsed.note,
+      signaturePngBase64: parsed.signaturePngBase64,
+    });
+    return { status: "CREATED" };
   }
 
-  return createTimesheetEvent(userId, {
-    type: "INDIRECT",
+  const queued = await VertretungRequestsFacade.createIndirectPending(userId, {
+    childNameText: parsed.childNameText,
     date: parsed.date,
-    childIds: [match.childId],
     startTime: parsed.startTime,
     endTime: parsed.endTime,
     note: parsed.note,
     signaturePngBase64: parsed.signaturePngBase64,
   });
+  return { status: "QUEUED", requestId: queued.id };
 }


### PR DESCRIPTION
 /admin/handlungsbedarf now shows four sections covering 7 problem types within today + 7 days:

  1. Krankheitsfälle — SB sick w/o substitute, substitute also sick, child absent but WORK booked,
   child absent (info)
  2. Weitere Fälle — Schedule block without SB, booked hours > scheduled (>30 min), missing
  Schweigepflichtsentbindung
  3. Vertretungs-Anträge — existing pending queue
  4. Indirekte Leistungen — existing pending INDIRECT queue

  Setup

  - Seed credentials: admin admin@lebenshilfe.de / password123, SB anna.schmidt@lebenshilfe.de / 
  password123
  - Pick weekdays within the next 7 days for all scenarios — past dates and dates >7 days out are
  filtered

  Test scenarios

  #: 1
  Trigger: Log in as Anna, create a SICK entry on a weekday where she has assigned children
  Expected flag: One "Vertretung fehlt" row per assigned child in Krankheitsfälle, each with
    "Vertretung eintragen" quick-action
  ────────────────────────────────────────
  #: 2
  Trigger: From row 1, pick a substitute in the popover
  Expected flag: Row disappears immediately
  ────────────────────────────────────────
  #: 3
  Trigger: Mark the chosen substitute SICK on the same date
  Expected flag: New "Vertreter krank" row (SUBSTITUTE_ALSO_SICK)
  ────────────────────────────────────────
  #: 4
  Trigger: Mark a child krank on a date that already has a WORK event
  Expected flag: CHILD_ABSENT_BUT_WORK_BOOKED row with "WORK löschen" button
  ────────────────────────────────────────
  #: 5
  Trigger: Create a child with a Schedule block on a weekday but no assignment + no Vertretung
  Expected flag: SCHEDULE_BLOCK_UNASSIGNED in Weitere Fälle — clicking the row should deep-link to

    /admin/children?childId=...&tab=calendar
  ────────────────────────────────────────
  #: 6
  Trigger: Book a WORK event >30 min longer than the scheduled block
  Expected flag: BOOKED_HOURS_OVER_SCHEDULE row showing booked vs scheduled minutes
  ────────────────────────────────────────
  #: 7
  Trigger: In /admin/children, set a child's schweigepflichtsentbindung to false
  Expected flag: MISSING_SCHWEIGEPFLICHT row (date-independent — shows once per child)