### PR TITLE
fix(security): stop logging PII + add pino redaction (F-03, COD-99)

### DIFF
--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -135,12 +135,13 @@ export const ChildrenFacade = {
 
   async create(input: CreateChildInput) {
     const parsed = CreateChildSchema.parse(input);
+    const created = await createChild(childFieldsFromCreate(parsed));
     logBusinessEvent("CHILD_CREATED", {
-      leosOne: parsed.leosOne,
+      childId: created.id,
       schoolId: parsed.schoolId,
-      name: parsed.firstName + " " + parsed.lastName,
+      leosOne: parsed.leosOne,
     });
-    return createChild(childFieldsFromCreate(parsed));
+    return created;
   },
 
   async update(id: string, input: UpdateChildInput) {

--- a/src/features/cost-bearers/facade.ts
+++ b/src/features/cost-bearers/facade.ts
@@ -31,11 +31,9 @@ export const CostBearersFacade = {
 
   async create(input: CostBearerInput) {
     const parsed = CreateKostentraegerSchema.parse(input);
-    logBusinessEvent("COST_BEARER_CREATED", {
-      name: parsed.name,
-      email: parsed.email,
-    });
-    return createKostentraeger(normalize(parsed));
+    const created = await createKostentraeger(normalize(parsed));
+    logBusinessEvent("COST_BEARER_CREATED", { costBearerId: created.id });
+    return created;
   },
 
   async update(id: string, input: CostBearerInput) {

--- a/src/features/invitations/facade.ts
+++ b/src/features/invitations/facade.ts
@@ -19,7 +19,7 @@ export const InvitationFacade = {
     role: Role = Role.SCHOOL_ASSISTANT,
   ) {
     CreateInvitationSchema.parse({ email, role });
-    logBusinessEvent("USER_INVITED", { role, email });
+    logBusinessEvent("USER_INVITED", { role });
     // Token generation, database insertion, and email dispatch are delegated to the service boundary
     return processNewInvitation(email, role);
   },

--- a/src/features/invitations/facade.ts
+++ b/src/features/invitations/facade.ts
@@ -11,7 +11,6 @@ import {
   getAllInvitations as fetchAllInvitations,
 } from "./services";
 import { Role } from "@/generated/prisma";
-import { logBusinessEvent } from "@/lib/logger";
 
 export const InvitationFacade = {
   async generateAndSendInvite(
@@ -19,7 +18,6 @@ export const InvitationFacade = {
     role: Role = Role.SCHOOL_ASSISTANT,
   ) {
     CreateInvitationSchema.parse({ email, role });
-    logBusinessEvent("USER_INVITED", { role });
     // Token generation, database insertion, and email dispatch are delegated to the service boundary
     return processNewInvitation(email, role);
   },

--- a/src/features/school-assistants/facade.ts
+++ b/src/features/school-assistants/facade.ts
@@ -60,14 +60,14 @@ export const SchoolAssistantsFacade = {
       );
     }
 
-    logBusinessEvent("SCHOOL_ASSISTANT_CREATED", { email: parsed.email });
-
-    return createProfileWithAttendances({
+    const created = await createProfileWithAttendances({
       email: parsed.email,
       name: parsed.name,
       fields: toFields(parsed),
       attendances: toAttendances(parsed),
     });
+    logBusinessEvent("SCHOOL_ASSISTANT_CREATED", { profileId: created.id });
+    return created;
   },
 
   async update(profileId: string, input: UpdateSchoolAssistantInput) {

--- a/src/features/workshops/facade.ts
+++ b/src/features/workshops/facade.ts
@@ -30,11 +30,12 @@ export const WorkshopsFacade = {
 
   async create(input: WorkshopInput) {
     const parsed = WorkshopSchema.parse(input);
-    logBusinessEvent("WORKSHOP_CREATED", { name: parsed.name });
-    return insertWorkshop(
+    const created = await insertWorkshop(
       parsed.name,
       normaliseDescription(parsed.description),
     );
+    logBusinessEvent("WORKSHOP_CREATED", { workshopId: created.id });
+    return created;
   },
 
   async update(id: string, input: UpdateWorkshopInput) {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -5,12 +5,14 @@ export async function onRequestError(
   request: unknown,
   context: unknown,
 ) {
+  const rawUrl = (request as { url?: string })?.url;
   logger.error(
     {
       err,
       request: {
         method: (request as { method?: string })?.method,
-        url: (request as { url?: string })?.url,
+        // path only — the query string may carry reset/invite tokens or ids
+        path: rawUrl ? rawUrl.split("?")[0] : undefined,
       },
       context,
     },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -66,7 +66,7 @@ export const auth = betterAuth({
           } catch (error) {
             // No matching profile (e.g. legacy invite without wizard data) — log and continue.
             logger.error(
-              { error, email: user.email },
+              { err: error, userId: user.id },
               "[auth] could not link Schulbegleiter profile",
             );
           }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,6 +2,45 @@ import pino from "pino";
 
 const isBrowser = typeof window !== "undefined";
 
+// Defense-in-depth: strip these PII/secret field names from server logs (shipped
+// to Alloy) even if a future call site passes them. Targeted names, not a blanket
+// "name", so useful non-PII keys like err.name survive.
+const REDACT_PATHS = [
+  "email",
+  "firstName",
+  "lastName",
+  "name",
+  "childName",
+  "childNameText",
+  "supervisorName",
+  "schulbegleiterName",
+  "subjectName",
+  "note",
+  "bemerkung",
+  "bemerkungen",
+  "bescheid",
+  "zvNeuNote",
+  "address",
+  "password",
+  "token",
+  "signaturePngBase64",
+  "signatureKey",
+  "*.email",
+  "*.firstName",
+  "*.lastName",
+  "*.childName",
+  "*.childNameText",
+  "*.note",
+  "*.bemerkung",
+  "*.bescheid",
+  "*.address",
+  "*.password",
+  "*.token",
+  "*.signaturePngBase64",
+  "err.meta",
+  "error.meta",
+];
+
 export const logger = pino({
   level: process.env.NEXT_PUBLIC_LOG_LEVEL || "info",
   formatters: {
@@ -16,6 +55,7 @@ export const logger = pino({
         },
       }
     : {
+        redact: { paths: REDACT_PATHS, remove: true },
         transport:
           process.env.LOG_PRETTY === "true"
             ? {

--- a/src/use-cases/create-school-assistant.ts
+++ b/src/use-cases/create-school-assistant.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@/lib/auth-guards";
 import { InvitationFacade } from "@/features/invitations/facade";
 import { SchoolAssistantsFacade } from "@/features/school-assistants/facade";
 import type { CreateSchoolAssistantInput } from "@/features/school-assistants/schemas";
+import { logBusinessEvent } from "@/lib/logger";
 
 /**
  * An admin creates a new Schulbegleiter:
@@ -12,13 +13,19 @@ import type { CreateSchoolAssistantInput } from "@/features/school-assistants/sc
 export async function createSchoolAssistantUseCase(
   input: CreateSchoolAssistantInput,
 ) {
-  await requireAdmin();
+  const actor = await requireAdmin();
 
   await SchoolAssistantsFacade.create(input);
-  await InvitationFacade.generateAndSendInvite(
+  const invitation = await InvitationFacade.generateAndSendInvite(
     input.email,
     Role.SCHOOL_ASSISTANT,
   );
+  // Who invited whom, by reference only (no email/PII).
+  logBusinessEvent("USER_INVITED", {
+    role: Role.SCHOOL_ASSISTANT,
+    invitationId: invitation.id,
+    invitedByUserId: actor.id,
+  });
 
   return { success: true };
 }

--- a/src/use-cases/invite-admin-user.ts
+++ b/src/use-cases/invite-admin-user.ts
@@ -6,10 +6,11 @@ import {
   type InviteAdminUserInput,
 } from "@/features/users/schemas";
 import { Role } from "@/generated/prisma";
+import { logBusinessEvent } from "@/lib/logger";
 
 export async function inviteAdminUserUseCase(input: InviteAdminUserInput) {
   // Anyone with admin or owner access may invite a new ADMIN; only OWNERs may invite a new OWNER.
-  await requireAdmin();
+  const actor = await requireAdmin();
 
   const parsed = InviteAdminUserSchema.parse(input);
 
@@ -22,7 +23,17 @@ export async function inviteAdminUserUseCase(input: InviteAdminUserInput) {
     throw new Error("Es existiert bereits ein Benutzer mit dieser E-Mail.");
   }
 
-  await InvitationFacade.generateAndSendInvite(parsed.email, parsed.role);
+  const invitation = await InvitationFacade.generateAndSendInvite(
+    parsed.email,
+    parsed.role,
+  );
+  // Who invited whom, by reference only (no email/PII): resolve the invitee via
+  // invitationId in the DB if needed.
+  logBusinessEvent("USER_INVITED", {
+    role: parsed.role,
+    invitationId: invitation.id,
+    invitedByUserId: actor.id,
+  });
 
   return { success: true };
 }


### PR DESCRIPTION
## What & why

Business-event and error logs were shipping personal data to `stdout` → Grafana Alloy: a disabled child's **full name** (`CHILD_CREATED`), **email addresses** (`USER_INVITED`, `SCHOOL_ASSISTANT_CREATED`, `COST_BEARER_CREATED`), and — via full `Error` objects — Prisma **`err.meta`** (which embeds field values). For a platform handling **GDPR Art. 9 (health/disability) data on minors**, the central log store becomes a shadow special-category datastore and a second breach surface.

Audit finding **F-03** (Critical) · **COD-99**. Refs GDPR Art. 9 & Art. 5(1)(c) (data minimisation), §22 BDSG, OWASP A09. Closes #72.

## Changes

**1. Log stable IDs / enums at the call sites — never PII**

| Event | Before | After |
|---|---|---|
| `CHILD_CREATED` | child full name | `childId, schoolId, leosOne` |
| `USER_INVITED` | email | `role` |
| `SCHOOL_ASSISTANT_CREATED` | email | `profileId` |
| `COST_BEARER_CREATED` | name + email | `costBearerId` |
| `WORKSHOP_CREATED` | name | `workshopId` |

`CHILD_ASSIGNED`, `TIMESHEET_CREATED` and `MONTHLY_REPORT_SUBMITTED` already logged IDs only.

**2. Fix the two error-log leaks**
- `src/lib/auth.ts` — the Schulbegleiter profile-link failure logs `userId` + a *serialized* error, not `email` + the raw error object.
- `src/instrumentation.ts` — the global error handler logs the request **path only**, dropping the query string (which can carry reset/invite tokens or ids).

**3. Defense-in-depth: pino redaction (`src/lib/logger.ts`)**
A `redact` allowlist (`remove: true`), **server-side only** (the branch that ships to Alloy), scrubs known PII/secret field names and Prisma `err.meta` even if a future call site slips one through. Field names are **targeted** (not a blanket `name`) so useful non-PII keys like `err.name` / `err.code` survive.

## Verification
- **Runtime test against the real logger**: simulated leaks (a name, three emails, an `err.meta` field value) are all stripped; `childId`, `userId`, `err.message`, `err.code`, `err.name` are kept.
- `npx tsc --noEmit`: clean.
- grep: no PII in any `logBusinessEvent` / `logger` call site.

## Out of scope / follow-up
- **Log-retention TTL on Alloy/Loki** (the 4th acceptance criterion on COD-99) is an ops/infra config on the Grafana side, not a code change — needs setting by someone with Grafana access.
- The full Art. 9 read/write **audit log** is tracked separately (F-12 / COD-108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
