### PR TITLE
feat(security): enforce 12-char min password + HIBP breach check (F-19, COD-115)

### DIFF
--- a/src/app/onboard/page.tsx
+++ b/src/app/onboard/page.tsx
@@ -63,7 +63,12 @@ export default function OnboardPage({
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!password.trim() || !name.trim()) return;
+    if (!name.trim()) return;
+    if (password.length < 12) {
+      setStatus("error");
+      setErrorMessage("Das Passwort muss mindestens 12 Zeichen lang sein.");
+      return;
+    }
 
     setStatus("loading");
     try {
@@ -189,6 +194,7 @@ export default function OnboardPage({
                       id="password"
                       type="password"
                       required
+                      minLength={12}
                       autoComplete="new-password"
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -27,8 +27,8 @@ function ResetPasswordForm() {
       return;
     }
 
-    if (password.length < 8) {
-      setErrorMsg("Das Passwort muss mindestens 8 Zeichen lang sein.");
+    if (password.length < 12) {
+      setErrorMsg("Das Passwort muss mindestens 12 Zeichen lang sein.");
       setStatus("error");
       return;
     }
@@ -42,7 +42,9 @@ function ResetPasswordForm() {
 
     if (result.error) {
       setErrorMsg(
-        "Der Reset-Link ist ungültig oder abgelaufen. Bitte fordere einen neuen an.",
+        result.error.code === "PASSWORD_COMPROMISED"
+          ? "Dieses Passwort taucht in bekannten Datenlecks auf. Bitte wähle ein anderes."
+          : "Der Reset-Link ist ungültig oder abgelaufen. Bitte fordere einen neuen an.",
       );
       setStatus("error");
     } else {
@@ -86,7 +88,7 @@ function ResetPasswordForm() {
         onChange={(e) => setPassword(e.target.value)}
         className="h-12"
         disabled={status === "loading"}
-        minLength={8}
+        minLength={12}
       />
       <Input
         type="password"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,11 +7,19 @@ import { sendMail } from "./mail";
 import { renderEmail } from "./email/render";
 import { ResetPasswordEmail } from "./email/templates/reset-password-email";
 import { logger } from "@/lib/logger";
+import { haveIBeenPwned } from "better-auth/plugins";
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: "mysql",
   }),
+  plugins: [
+    // Reject breached passwords (HIBP k-anonymity: only a hashed SHA-1 prefix leaves the server).
+    haveIBeenPwned({
+      customPasswordCompromisedMessage:
+        "Dieses Passwort taucht in bekannten Datenlecks auf. Bitte wähle ein anderes.",
+    }),
+  ],
   user: {
     additionalFields: {
       role: {
@@ -22,6 +30,7 @@ export const auth = betterAuth({
   },
   emailAndPassword: {
     enabled: true,
+    minPasswordLength: 12,
     sendResetPassword: async ({ url, user }) => {
       const { html, text } = await renderEmail(
         createElement(ResetPasswordEmail, { resetUrl: url }),


### PR DESCRIPTION
## What & why

Passwords were only length-checked **client-side** (≥8 on reset, non-empty on signup); the server ran on better-auth's **default minimum of 8**, and the client check is trivially bypassable via the direct sign-up/reset API. For accounts that guard **GDPR Art. 9 data on minors**, weak or already-breached passwords are a real account-takeover path (compounding the missing brute-force protection, F-09).

Audit finding **F-19** (High) · **COD-115**. Refs OWASP A07, OWASP ASVS 5.0 (V6). Closes #88.

## Changes
- **`src/lib/auth.ts`** — `emailAndPassword.minPasswordLength = 12`, server-enforced across **sign-up, reset-password and change-password** (all three read this one config). Added the better-auth **`haveIBeenPwned`** plugin to reject breached passwords using **k-anonymity** — only a hashed SHA-1 *prefix* is sent to `api.pwnedpasswords.com`, never the password — with a German rejection message. No forced composition rules (NIST/OWASP-ASVS guidance): length + breach check only.
- **`/onboard`** and **`/reset-password`** — client hints synced to 12 (`minLength` attribute + JS length check) so the UI matches the server.
- **`/reset-password`** — surfaces a clear "password compromised" message on that specific error, instead of the previous generic "link invalid/expired".

## Verification (against the running sign-up API, DB up)

| Input | Result |
|---|---|
| 7-char password | `PASSWORD_TOO_SHORT` (400) |
| 12-char (boundary) | accepted → reaches invitation gate |
| breached `password123456` | `PASSWORD_COMPROMISED` (400, German message) |
| strong 16-char | passes both checks |

`npx tsc --noEmit` clean.

## Deploy / ops notes
- Production must allow **egress to `api.pwnedpasswords.com`** (the check fails closed with a 500 "please try again later" if unreachable).
- The hashed-prefix lookup is a new outbound flow — record it as a recipient in the **Art. 30 RoPA**.
- Related follow-ups (separate issues): persistent brute-force protection / account lockout (**F-09 / COD-105**) and MFA for admins (**F-20 / COD-116**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
