### PR TITLE
fix(security): neutralize CSV formula injection in Kostenträger export (F-14, COD-110)

### DIFF
--- a/src/features/kostentraeger-export/render/csv.ts
+++ b/src/features/kostentraeger-export/render/csv.ts
@@ -3,15 +3,17 @@ import type { ExportDocument } from "../schemas";
 
 const SEPARATOR = ";";
 
+// Spreadsheet formula injection: a cell beginning with = + - @ (or a tab/CR) is
+// executed as a formula by Excel/Sheets. Prefix such values with an apostrophe
+// so the recipient's spreadsheet renders them as literal text.
+const FORMULA_LEAD = /^[=+\-@\t\r]/;
+
 function escapeCell(value: string): string {
-  if (
-    value.includes(SEPARATOR) ||
-    value.includes('"') ||
-    value.includes("\n")
-  ) {
-    return `"${value.replace(/"/g, '""')}"`;
+  const safe = FORMULA_LEAD.test(value) ? `'${value}` : value;
+  if (safe.includes(SEPARATOR) || safe.includes('"') || safe.includes("\n")) {
+    return `"${safe.replace(/"/g, '""')}"`;
   }
-  return value;
+  return safe;
 }
 
 /**


### PR DESCRIPTION
## What & why

The Kostenträger CSV export's `escapeCell` only quoted cells containing `;`, `"` or a newline — it did **not** neutralize the spreadsheet formula-lead characters `=`, `+`, `-`, `@` (nor tab / CR). Tainted fields (event **notes**, **school-assistant** and **child names**) were written verbatim, so a cell like `=HYPERLINK(...)` or `=cmd|'/C calc'!A1` would **execute when the recipient opens the CSV** in Excel/LibreOffice/Sheets. Because the recipient is the Kostenträger / Leitung — a third party handling Art. 9 data — this is stored CSV/formula injection (an authenticated SB or admin who controls a note/name is the attacker).

Audit finding **F-14** (High) · **COD-110**. Refs OWASP A03 (Injection), OWASP ASVS 5.0 V1 (output encoding). Closes #83.

## Change (`src/features/kostentraeger-export/render/csv.ts`)
`escapeCell` now prefixes any value beginning with `= + - @`, tab or CR with a single apostrophe, so the recipient's spreadsheet renders it as literal text. The existing separator/quote/newline escaping is applied afterwards and is unchanged.

```
const FORMULA_LEAD = /^[=+\-@\t\r]/;
// safe = FORMULA_LEAD.test(value) ? `'${value}` : value;  then existing quoting
```

The **XLSX** path is unaffected (exceljs writes string-typed cells, which are not evaluated as formulas) and the **PDF** path draws literal glyphs — both were already safe; only the CSV renderer needed fixing.

## Verification
Rendered a document whose cells contain `=cmd|'/C calc'!A1`, `@SUM(1+1)`, `+SUM(A1)`, `=HYPERLINK("http://evil","x")` and a `-30 Minuten` note:

| Input cell | Output |
|---|---|
| `=cmd\|'/C calc'!A1` | `'=cmd\|'/C calc'!A1` (inert) |
| `@SUM(1+1)` | `'@SUM(1+1)` |
| `+SUM(A1)` | `'+SUM(A1)` |
| `=HYPERLINK("http://evil","x")` | `"'=HYPERLINK(""http://evil"",""x"")"` (prefixed **and** quoted) |
| `-30 Minuten` | `'-30 Minuten` |
| `Normaler Name`, `Alles gut`, dates/times | unchanged |

Also confirmed no field begins with a raw formula character, the UTF-8 BOM + `;` delimiter + quote-doubling still work (DE-locale Excel opens correctly), and `tsc --noEmit` is clean.

## Note
Apostrophe-prefixing is the OWASP-recommended mitigation; it can be faintly visible in viewers that don't honour the text marker (e.g. a note that legitimately starts with `-`). That's the accepted cosmetic cost of neutralisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
