### PR TITLE
feat(security): persistent (DB-backed) rate limiting (F-09, COD-105)

### DIFF
--- a/prisma/migrations/20260707102351_add_rate_limit/migration.sql
+++ b/prisma/migrations/20260707102351_add_rate_limit/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE `rate_limit` (
+    `id` VARCHAR(191) NOT NULL,
+    `key` VARCHAR(191) NULL,
+    `count` INTEGER NULL,
+    `lastRequest` BIGINT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -414,3 +414,15 @@ model PendingVertretungRequest {
   @@index([status, date])
   @@map("pending_vertretung_request")
 }
+
+// better-auth rate-limit storage (F-09). Persists throttle counters in MySQL so
+// they survive restarts and are shared across replicas (the default in-process
+// Map does not). Written/read by better-auth's "database" rateLimit storage.
+model RateLimit {
+  id          String  @id @default(cuid())
+  key         String?
+  count       Int?
+  lastRequest BigInt?
+
+  @@map("rate_limit")
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,6 +20,18 @@ export const auth = betterAuth({
         "Dieses Passwort taucht in bekannten Datenlecks auf. Bitte wähle ein anderes.",
     }),
   ],
+  rateLimit: {
+    enabled: true,
+    storage: "database",
+    // Tightened per-IP limits on top of better-auth's defaults. Uses the
+    // RateLimit table (prisma/schema.prisma) so counters survive restarts and
+    // are shared across replicas — the default in-process Map does not.
+    customRules: {
+      "/sign-in/email": { window: 60, max: 10 },
+      "/forget-password": { window: 300, max: 3 },
+      "/reset-password": { window: 300, max: 5 },
+    },
+  },
   user: {
     additionalFields: {
       role: {


### PR DESCRIPTION
## What & why

better-auth's rate limiter is on in production but defaults to an **in-process `Map`** — per-process, wiped on every restart/redeploy — so brute-force / credential-stuffing throttling was effectively ineffective in the Docker deploy (and not shared across replicas). Audit finding **F-09** (High) · **COD-105**. Refs OWASP A07, OWASP ASVS 5.0 (V6).

## Changes
- **New `RateLimit` Prisma model + migration** (`20260707102351_add_rate_limit`) so throttle counters live in MySQL — they now **survive restarts and are shared across replicas**.
- **`src/lib/auth.ts`**: `rateLimit { enabled: true, storage: "database", customRules }` with tightened per-IP limits — `/sign-in/email` 10/60s, `/forget-password` 3/300s, `/reset-password` 5/300s.
- IP is resolved from `X-Forwarded-For` (better-auth default), so the limiter keys on the real client behind Caddy (AC-3). It is *skipped* if no IP resolves; XFF-spoofing is mitigated by binding the app to loopback (**F-16**).

**No account lockout** — deliberately omitted: OWASP/NIST prefer throttling + MFA, and a hard per-account lockout is a DoS-by-lockout vector.

## Verification
Ran the sign-in endpoint with a fixed `X-Forwarded-For` (rule 10/60s):

| Request | Result |
|---|---|
| 1–10 | `401` (invalid creds, allowed) |
| 11+ | `429` (throttled) |

The `rate_limit` table then held a row (`key "203.0.113.7|/sign-in/email"`, `count 10`, `lastRequest` bigint) — confirming DB-backed persistence and that the `BigInt` write works. `tsc --noEmit` clean.

## Notes
- The migration is applied automatically on deploy (Dockerfile runs `prisma migrate deploy`).
- **F-11 (COD-107)** also edits `auth.ts`, but at a different spot (after `plugins` vs. before `databaseHooks`), so the two should auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
