### PR TITLE
fix(security): bind app port to loopback so Caddy can't be bypassed (F-16, COD-112)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## What & why

`docker-compose.prod.yml` published the app as `"3000:3000"`, which binds **`0.0.0.0:3000`** on the host — so the Next app was reachable **directly** on `:3000` (plain HTTP, no TLS, none of the F-02 security headers, HSTS, etc.), **bypassing Caddy**. Audit finding **F-16** (High) · **COD-112**. Refs OWASP A05, GDPR Art. 32.

## Change

`docker-compose.prod.yml` — one line:

```diff
     ports:
-      - "3000:3000"
+      # Bind to loopback only: Caddy runs on the host and reverse-proxies to
+      # localhost:3000. Publishing on 0.0.0.0 would expose the app directly on
+      # :3000, bypassing Caddy's TLS and security headers (F-16).
+      - "127.0.0.1:3000:3000"
```

Caddy runs on the host (`Caddyfile`: `reverse_proxy localhost:3000`), so it still reaches the app on `127.0.0.1:3000` unchanged. External access on `:3000` becomes **impossible regardless of host firewall configuration** — which also sidesteps the well-known **Docker-publishes-past-`ufw`** rule-ordering footgun (Docker's iptables rules are evaluated before `ufw`, so a `0.0.0.0` publish can remain internet-reachable even with a host firewall "blocking" it). A loopback bind doesn't depend on the firewall being correct.

## Verification

```
$ docker compose -f docker-compose.prod.yml config
    ports:
      - mode: ingress
        host_ip: 127.0.0.1      # ← loopback only
        target: 3000
        published: "3000"
```
Compose config validates; the mapping resolves to `host_ip 127.0.0.1`.

## Notes
- Defence-in-depth even where a cloud firewall already blocks `:3000`: the app is now unreachable off-host by construction, not by firewall policy.
- No app/runtime code changed; Caddy config unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
