### PR TITLE
fix(seed): use password that satisfies the 12-char + HIBP policy

### DIFF
--- a/scripts/seed-admin.ts
+++ b/scripts/seed-admin.ts
@@ -4,7 +4,7 @@ import { Role } from "../src/generated/prisma";
 
 async function seed() {
   const email = "admin@lebenshilfe.de";
-  const password = "password123";
+  const password = "Lebenshilfe-Dev-2026!";
 
   console.log("Seeding database...");
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -9,34 +9,36 @@ type SeedUser = {
   role: Role;
 };
 
+const SEED_PASSWORD = "Lebenshilfe-Dev-2026!";
+
 const USERS: SeedUser[] = [
   {
     email: "owner@lebenshilfe.de",
-    password: "password123",
+    password: SEED_PASSWORD,
     name: "Olivia Owner",
     role: Role.OWNER,
   },
   {
     email: "admin@lebenshilfe.de",
-    password: "password123",
+    password: SEED_PASSWORD,
     name: "System Admin",
     role: Role.ADMIN,
   },
   {
     email: "anna.schmidt@lebenshilfe.de",
-    password: "password123",
+    password: SEED_PASSWORD,
     name: "Anna Schmidt",
     role: Role.SCHOOL_ASSISTANT,
   },
   {
     email: "ben.weber@lebenshilfe.de",
-    password: "password123",
+    password: SEED_PASSWORD,
     name: "Ben Weber",
     role: Role.SCHOOL_ASSISTANT,
   },
   {
     email: "clara.becker@lebenshilfe.de",
-    password: "password123",
+    password: SEED_PASSWORD,
     name: "Clara Becker",
     role: Role.SCHOOL_ASSISTANT,
   },


### PR DESCRIPTION
## Problem

The server now enforces a **12-character minimum** and rejects passwords found in the **Have I Been Pwned** breach corpus (`src/lib/auth.ts`: `minPasswordLength: 12` + the `haveIBeenPwned` plugin).

The seed scripts still used `"password123"` — 11 chars and heavily breached (2.2M+ HIBP hits) — so the first sign-up failed and the whole seed aborted:

```
ERROR [Better Auth]: Password is too short
Error: Sign-up failed for owner@lebenshilfe.de (400): {"message":"Password too short","code":"PASSWORD_TOO_SHORT"}
```

## Fix

Switch both seed scripts to `"Lebenshilfe-Dev-2026!"` (21 chars, verified absent from HIBP via the same k-anonymity API the plugin uses):

- `scripts/seed.ts` — extracted a single `SEED_PASSWORD` constant used by all seeded users.
- `scripts/seed-admin.ts` — updated the standalone admin seed.

## Verification

- Confirmed the new password is ≥12 chars and returns no match from the HIBP range API.
- `npm run db:seed` runs to completion (verified by the author against the local dev DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)