### PR TITLE
feat(admin): add Karte nav item linking to /admin/map

### DIFF
--- a/src/app/admin/_components/nav-items.ts
+++ b/src/app/admin/_components/nav-items.ts
@@ -2,6 +2,7 @@ import {
   Baby,
   BookOpen,
   Home,
+  MapPinned,
   Palmtree,
   School,
   ShieldCheck,
@@ -69,6 +70,12 @@ export const NAV_ITEMS: readonly NavItem[] = [
     label: "Handlungsbedarf",
     description: "Offene Vertretungs-Anträge zuordnen.",
     icon: TriangleAlert,
+  },
+  {
+    href: "/admin/map",
+    label: "Karte",
+    description: "Einsätze eines Tages auf der Karte anzeigen.",
+    icon: MapPinned,
   },
 ];
 


### PR DESCRIPTION
## Summary

The `/admin/map` Einsatz-Karte had no entry point anywhere in the admin UI — it was only reachable by typing the URL. This adds a **Karte** navigation item pointing at `/admin/map`.

Navigation is data-driven from `NAV_ITEMS` in `src/app/admin/_components/nav-items.ts`, so a single entry surfaces the map across all three navigation surfaces:

- Desktop sidebar (`admin-shell.tsx`)
- Mobile bottom tab bar (`admin-bottom-tab-bar.tsx`)
- Dashboard card grid (`admin/page.tsx`)

The item is placed at the end of the *Verwaltung* group with the `MapPinned` icon (chosen over `Map` to avoid shadowing the JS `Map` global, and it fits the marker-based map).

## Notes

- The bottom tab bar's `grid-cols-5` now holds 10 items — two clean rows of five.
- No changes to the map page or its layout; the existing full-bleed `/admin/map` layout branch in `admin-shell.tsx` already handles the route.

## Testing

- `eslint` passes on the changed file.
- `prettier --check` passes.
- `tsc --noEmit`: no new errors introduced (the 4 pre-existing `twoFactorEnabled`/Prisma errors are present on `main` and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)