### PR TITLE
feat(children): assign Schulbegleiter before invitation is accepted

### DIFF
--- a/prisma/migrations/20260714120000_zuweisung_to_profile/migration.sql
+++ b/prisma/migrations/20260714120000_zuweisung_to_profile/migration.sql
@@ -1,0 +1,27 @@
+-- Repoint ChildAssignment (Zuweisung) from the auth User to the
+-- SchoolAssistantProfile, so an assistant can be assigned to a child before
+-- they accept their invitation (a profile exists from creation; a User only
+-- exists after acceptance).
+
+-- Add the new FK column, nullable for the backfill window.
+ALTER TABLE `child_assignment` ADD COLUMN `profileId` VARCHAR(191) NULL;
+
+-- Backfill: every existing assignment points at an accepted assistant, whose
+-- profile is uniquely linked via SchoolAssistantProfile.userId.
+UPDATE `child_assignment` `ca`
+JOIN `school_assistant_profile` `p` ON `p`.`userId` = `ca`.`userId`
+SET `ca`.`profileId` = `p`.`id`;
+
+-- Safety net: drop any assignment that could not be matched to a profile
+-- (would otherwise block the NOT NULL + FK below). None are expected.
+DELETE FROM `child_assignment` WHERE `profileId` IS NULL;
+
+-- Drop the old User FK, its index, and the column.
+ALTER TABLE `child_assignment` DROP FOREIGN KEY `child_assignment_userId_fkey`;
+DROP INDEX `child_assignment_userId_idx` ON `child_assignment`;
+ALTER TABLE `child_assignment` DROP COLUMN `userId`;
+
+-- Finalise the new column: NOT NULL, indexed, FK to the profile.
+ALTER TABLE `child_assignment` MODIFY `profileId` VARCHAR(191) NOT NULL;
+CREATE INDEX `child_assignment_profileId_idx` ON `child_assignment`(`profileId`);
+ALTER TABLE `child_assignment` ADD CONSTRAINT `child_assignment_profileId_fkey` FOREIGN KEY (`profileId`) REFERENCES `school_assistant_profile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,7 +52,6 @@ model User {
   sessions                   Session[]
   accounts                   Account[]
   twoFactors                 TwoFactor[]
-  assignments                ChildAssignment[]
   events                     Event[]
   monthlyReports             MonthlyReport[]
   profile                    SchoolAssistantProfile?
@@ -241,16 +240,16 @@ model HolidayPlanEntry {
 model ChildAssignment {
   id        String   @id @default(cuid())
   childId   String
-  userId    String
+  profileId String
   weekday   Int      @default(0)
   startTime String   @default("08:00")
   endTime   String   @default("14:00")
   tandem    Boolean  @default(false)
   createdAt DateTime @default(now())
-  child     Child    @relation(fields: [childId], references: [id], onDelete: Cascade)
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  child     Child                  @relation(fields: [childId], references: [id], onDelete: Cascade)
+  profile   SchoolAssistantProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
 
-  @@index([userId])
+  @@index([profileId])
   @@index([childId, weekday])
   @@map("child_assignment")
 }
@@ -395,6 +394,7 @@ model SchoolAssistantProfile {
   user              User?                @relation(fields: [userId], references: [id], onDelete: Cascade)
   pool              Pool?                @relation(fields: [poolId], references: [id], onDelete: SetNull)
   attendances       WorkshopAttendance[]
+  assignments       ChildAssignment[]
 
   @@index([status])
   @@index([poolId])

--- a/scripts/seed-children.ts
+++ b/scripts/seed-children.ts
@@ -20,9 +20,11 @@ async function run() {
     process.exit(1);
   }
 
-  const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) {
-    console.error(`No user found with email ${email}`);
+  const profile = await prisma.schoolAssistantProfile.findUnique({
+    where: { email },
+  });
+  if (!profile) {
+    console.error(`No Schulbegleiter profile found with email ${email}`);
     process.exit(1);
   }
 
@@ -45,15 +47,15 @@ async function run() {
     });
 
     const existingAssignment = await prisma.childAssignment.findFirst({
-      where: { childId: child.id, userId: user.id },
+      where: { childId: child.id, profileId: profile.id },
     });
     if (!existingAssignment) {
       await prisma.childAssignment.create({
-        data: { childId: child.id, userId: user.id },
+        data: { childId: child.id, profileId: profile.id },
       });
     }
     console.log(
-      `  assigned ${child.firstName} ${child.lastName} → ${user.email}`,
+      `  assigned ${child.firstName} ${child.lastName} → ${profile.email}`,
     );
 
     if (withSchedules) {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -330,7 +330,7 @@ async function wipeSeedData() {
     where: { user: { email: { in: seedEmails } } },
   });
   await prisma.childAssignment.deleteMany({
-    where: { user: { email: { in: seedEmails } } },
+    where: { profile: { email: { in: seedEmails } } },
   });
   await prisma.childAbsence.deleteMany({
     where: { childId: { in: childIds } },
@@ -526,11 +526,24 @@ async function enrichProfiles() {
   });
 }
 
-async function assignChildren(usersByEmail: Record<string, string>) {
+async function assignChildren() {
   console.log("Assigning children to school assistants per weekday…");
-  const annaId = usersByEmail["anna.schmidt@lebenshilfe.de"];
-  const benId = usersByEmail["ben.weber@lebenshilfe.de"];
-  const claraId = usersByEmail["clara.becker@lebenshilfe.de"];
+  const profiles = await prisma.schoolAssistantProfile.findMany({
+    where: {
+      email: {
+        in: [
+          "anna.schmidt@lebenshilfe.de",
+          "ben.weber@lebenshilfe.de",
+          "clara.becker@lebenshilfe.de",
+        ],
+      },
+    },
+    select: { id: true, email: true },
+  });
+  const byEmail = Object.fromEntries(profiles.map((p) => [p.email, p.id]));
+  const annaId = byEmail["anna.schmidt@lebenshilfe.de"];
+  const benId = byEmail["ben.weber@lebenshilfe.de"];
+  const claraId = byEmail["clara.becker@lebenshilfe.de"];
 
   // Anna splits her week: Lena Mon/Wed/Fri, Max Tue/Thu.
   // Ben covers Mia all five weekdays. Clara covers Paul all five weekdays.
@@ -539,7 +552,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
   // the app: WEEKDAYS[0]="mon" and (getUTCDay()+6)%7), so Mon=0 … Fri=4.
   const assignments: Array<{
     childId: string;
-    userId: string;
+    profileId: string;
     weekday: number;
     startTime: string;
     endTime: string;
@@ -548,7 +561,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     // Anna ↔ Lena (Mon/Wed/Fri)
     {
       childId: "seed-lena-fischer",
-      userId: annaId,
+      profileId: annaId,
       weekday: 0,
       startTime: "08:00",
       endTime: "13:00",
@@ -556,7 +569,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-lena-fischer",
-      userId: annaId,
+      profileId: annaId,
       weekday: 2,
       startTime: "08:00",
       endTime: "13:00",
@@ -564,7 +577,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-lena-fischer",
-      userId: annaId,
+      profileId: annaId,
       weekday: 4,
       startTime: "08:00",
       endTime: "13:00",
@@ -573,7 +586,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     // Anna ↔ Max (Tue/Thu)
     {
       childId: "seed-max-huber",
-      userId: annaId,
+      profileId: annaId,
       weekday: 1,
       startTime: "08:00",
       endTime: "12:30",
@@ -581,7 +594,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-max-huber",
-      userId: annaId,
+      profileId: annaId,
       weekday: 3,
       startTime: "08:00",
       endTime: "12:30",
@@ -590,7 +603,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     // Ben ↔ Mia (full week)
     {
       childId: "seed-mia-bauer",
-      userId: benId,
+      profileId: benId,
       weekday: 0,
       startTime: "09:00",
       endTime: "14:00",
@@ -598,7 +611,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-mia-bauer",
-      userId: benId,
+      profileId: benId,
       weekday: 1,
       startTime: "09:00",
       endTime: "14:00",
@@ -606,7 +619,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-mia-bauer",
-      userId: benId,
+      profileId: benId,
       weekday: 2,
       startTime: "09:00",
       endTime: "14:00",
@@ -614,7 +627,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-mia-bauer",
-      userId: benId,
+      profileId: benId,
       weekday: 3,
       startTime: "09:00",
       endTime: "14:00",
@@ -622,7 +635,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-mia-bauer",
-      userId: benId,
+      profileId: benId,
       weekday: 4,
       startTime: "09:00",
       endTime: "14:00",
@@ -631,7 +644,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     // Clara ↔ Paul (full week)
     {
       childId: "seed-paul-koch",
-      userId: claraId,
+      profileId: claraId,
       weekday: 0,
       startTime: "08:00",
       endTime: "13:00",
@@ -639,7 +652,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-paul-koch",
-      userId: claraId,
+      profileId: claraId,
       weekday: 1,
       startTime: "08:00",
       endTime: "13:00",
@@ -647,7 +660,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-paul-koch",
-      userId: claraId,
+      profileId: claraId,
       weekday: 2,
       startTime: "08:00",
       endTime: "13:00",
@@ -655,7 +668,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-paul-koch",
-      userId: claraId,
+      profileId: claraId,
       weekday: 3,
       startTime: "08:00",
       endTime: "13:00",
@@ -663,7 +676,7 @@ async function assignChildren(usersByEmail: Record<string, string>) {
     },
     {
       childId: "seed-paul-koch",
-      userId: claraId,
+      profileId: claraId,
       weekday: 4,
       startTime: "08:00",
       endTime: "13:00",
@@ -1016,7 +1029,7 @@ async function main() {
   await seedHolidayPlans();
   await seedSchools();
   await seedChildrenAndSchedules();
-  await assignChildren(usersByEmail);
+  await assignChildren();
   await seedVertretungen(usersByEmail);
   await seedChildAbsences();
   await enrichProfiles();

--- a/src/app/admin/children/page.tsx
+++ b/src/app/admin/children/page.tsx
@@ -22,9 +22,10 @@ export default async function ChildrenPage() {
         id: k.id,
         name: k.name,
       }))}
-      schoolAssistantOptions={schoolAssistants
-        .filter((p) => !!p.userId)
-        .map((p) => ({ id: p.userId as string, name: p.name }))}
+      schoolAssistantOptions={schoolAssistants.map((p) => ({
+        id: p.id,
+        name: p.name,
+      }))}
       schoolOptions={schools.map((s) => ({ id: s.id, name: s.name }))}
     />
   );

--- a/src/app/admin/map/_components/map-hover-card.tsx
+++ b/src/app/admin/map/_components/map-hover-card.tsx
@@ -35,7 +35,7 @@ export function MapHoverCard({ school }: { school: MapSchool }) {
                 <ul className="mt-0.5 space-y-0.5">
                   {child.assistants.map((a) => (
                     <li
-                      key={`${child.id}-${a.userId}`}
+                      key={`${child.id}-${a.profileId}`}
                       className="text-xs text-foreground"
                     >
                       {a.name}

--- a/src/app/admin/map/_components/map-search-overlay.tsx
+++ b/src/app/admin/map/_components/map-search-overlay.tsx
@@ -35,7 +35,7 @@ function buildIndex(schools: MapSchool[]): Entry[] {
         searchValue: `kind:${fullName}|${school.name}|${child.id}|${assistantNames}`,
       });
       for (const a of child.assistants) {
-        const dedupeKey = `${school.key}::${a.userId}`;
+        const dedupeKey = `${school.key}::${a.profileId}`;
         if (seenAssistants.has(dedupeKey)) continue;
         seenAssistants.add(dedupeKey);
         entries.push({
@@ -43,7 +43,7 @@ function buildIndex(schools: MapSchool[]): Entry[] {
           schoolName: school.name || "Schule",
           label: a.name,
           kind: "assistant",
-          searchValue: `sb:${a.name}|${school.name}|${a.userId}`,
+          searchValue: `sb:${a.name}|${school.name}|${a.profileId}`,
         });
       }
     }

--- a/src/app/admin/map/actions.ts
+++ b/src/app/admin/map/actions.ts
@@ -41,7 +41,7 @@ export async function getMapDataForDate(date: string): Promise<MapPayload> {
       firstName: child.firstName,
       lastName: child.lastName,
       assistants: dayAssignments.map((a) => ({
-        userId: a.userId,
+        profileId: a.profileId,
         name: a.userName,
         tandem: a.tandem,
         startTime: a.startTime,

--- a/src/app/admin/map/types.ts
+++ b/src/app/admin/map/types.ts
@@ -1,5 +1,5 @@
 export type MapAssistant = {
-  userId: string;
+  profileId: string;
   name: string;
   tandem: boolean;
   startTime: string;

--- a/src/features/children/components/calendar/day-quick-add.tsx
+++ b/src/features/children/components/calendar/day-quick-add.tsx
@@ -447,13 +447,15 @@ function DayAssignmentForm({
   onSaved: () => void;
   onBack: () => void;
 }) {
-  const [userId, setUserId] = useState(schoolAssistantOptions[0]?.id ?? "");
+  const [profileId, setProfileId] = useState(
+    schoolAssistantOptions[0]?.id ?? "",
+  );
   const [tandem, setTandem] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function handleSave() {
-    if (!userId) {
+    if (!profileId) {
       setError("Bitte Schulbegleiter wählen.");
       return;
     }
@@ -464,7 +466,7 @@ function DayAssignmentForm({
       // pin them to the visible day boundaries.
       await createAssignmentAction({
         childId,
-        userId,
+        profileId,
         weekday,
         startTime: "00:00",
         endTime: "23:59",
@@ -486,8 +488,8 @@ function DayAssignmentForm({
       <div className="text-xs font-medium">Neue Zuweisung</div>
       <SchoolAssistantCombobox
         options={schoolAssistantOptions}
-        value={userId || null}
-        onChange={(id) => setUserId(id ?? "")}
+        value={profileId || null}
+        onChange={(id) => setProfileId(id ?? "")}
         placeholder="Schulbegleiter…"
       />
       <label className="flex cursor-pointer items-center gap-2">

--- a/src/features/children/components/calendar/event-form-assignment.tsx
+++ b/src/features/children/components/calendar/event-form-assignment.tsx
@@ -33,7 +33,7 @@ export function EventFormAssignment({
   onSaved,
   onCancel,
 }: Props) {
-  const [userId, setUserId] = useState<string>(
+  const [profileId, setProfileId] = useState<string>(
     schoolAssistantOptions[0]?.id ?? "",
   );
   const [tandem, setTandem] = useState(false);
@@ -44,7 +44,7 @@ export function EventFormAssignment({
 
   async function handleSubmit() {
     setError(null);
-    if (!userId) {
+    if (!profileId) {
       setError("Bitte Schulbegleiter wählen.");
       return;
     }
@@ -52,7 +52,7 @@ export function EventFormAssignment({
     try {
       await createAssignmentAction({
         childId,
-        userId,
+        profileId,
         weekday,
         startTime: start,
         endTime: end,
@@ -96,8 +96,8 @@ export function EventFormAssignment({
         <SchoolAssistantCombobox
           id="ev-sb"
           options={schoolAssistantOptions}
-          value={userId || null}
-          onChange={(id) => setUserId(id ?? "")}
+          value={profileId || null}
+          onChange={(id) => setProfileId(id ?? "")}
         />
       </Field>
       <label className="flex cursor-pointer items-start gap-2">

--- a/src/features/children/components/calendar/school-assistant-combobox.tsx
+++ b/src/features/children/components/calendar/school-assistant-combobox.tsx
@@ -64,7 +64,7 @@ export function SchoolAssistantCombobox({
             {selected
               ? selected.name
               : options.length === 0
-                ? "Keine angenommenen Schulbegleiter."
+                ? "Keine Schulbegleiter."
                 : placeholder}
           </span>
           <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />

--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -168,7 +168,7 @@ export const ChildrenFacade = {
     const parsed = AssignmentSchema.parse(input);
     logBusinessEvent("CHILD_ASSIGNED", {
       childId: parsed.childId,
-      userId: parsed.userId,
+      profileId: parsed.profileId,
     });
     return createAssignment(parsed);
   },

--- a/src/features/children/schemas.ts
+++ b/src/features/children/schemas.ts
@@ -120,7 +120,7 @@ export type UpdateChildInput = z.infer<typeof UpdateChildSchema>;
 
 export const AssignmentSchema = z.object({
   childId: z.string().min(1),
-  userId: z.string().min(1),
+  profileId: z.string().min(1),
   weekday: z.number().int().min(0).max(6),
   startTime: timeString,
   endTime: timeString,

--- a/src/features/children/serialize.ts
+++ b/src/features/children/serialize.ts
@@ -3,7 +3,7 @@ import type { ChildWithRelations } from "./services";
 
 export type SerializedAssignment = {
   id: string;
-  userId: string;
+  profileId: string;
   userName: string;
   weekday: number;
   startTime: string;
@@ -133,8 +133,8 @@ export function serializeChild(c: ChildWithRelations): SerializedChild {
     pool: c.pool ? { id: c.pool.id, name: c.pool.name } : null,
     assignments: c.assignments.map((a) => ({
       id: a.id,
-      userId: a.userId,
-      userName: a.user.name,
+      profileId: a.profileId,
+      userName: a.profile.name,
       weekday: a.weekday,
       startTime: a.startTime,
       endTime: a.endTime,

--- a/src/features/children/services/assignments.ts
+++ b/src/features/children/services/assignments.ts
@@ -1,21 +1,21 @@
 import { prisma } from "@/lib/prisma";
 import type { Prisma } from "@/generated/prisma";
 
-export type AssignmentWithUser = Prisma.ChildAssignmentGetPayload<{
-  include: { user: true };
+export type AssignmentWithProfile = Prisma.ChildAssignmentGetPayload<{
+  include: { profile: true };
 }>;
 
 export async function listAssignmentsForChild(childId: string) {
   return prisma.childAssignment.findMany({
     where: { childId },
-    include: { user: true },
+    include: { profile: true },
     orderBy: [{ weekday: "asc" }, { startTime: "asc" }],
   });
 }
 
 export async function listAssignmentsForUser(userId: string) {
   return prisma.childAssignment.findMany({
-    where: { userId },
+    where: { profile: { userId } },
     include: { child: true },
     orderBy: [{ weekday: "asc" }, { startTime: "asc" }],
   });
@@ -23,7 +23,7 @@ export async function listAssignmentsForUser(userId: string) {
 
 export async function createAssignment(data: {
   childId: string;
-  userId: string;
+  profileId: string;
   weekday: number;
   startTime: string;
   endTime: string;
@@ -35,7 +35,7 @@ export async function createAssignment(data: {
 export async function updateAssignment(
   id: string,
   data: Partial<{
-    userId: string;
+    profileId: string;
     weekday: number;
     startTime: string;
     endTime: string;
@@ -60,7 +60,7 @@ export async function getAssignmentCoverage(
 ): Promise<Set<string>> {
   if (childIds.length === 0) return new Set();
   const rows = await prisma.childAssignment.findMany({
-    where: { userId, childId: { in: childIds }, weekday },
+    where: { profile: { userId }, childId: { in: childIds }, weekday },
     select: { childId: true },
   });
   return new Set(rows.map((r) => r.childId));

--- a/src/features/children/services/children.ts
+++ b/src/features/children/services/children.ts
@@ -6,7 +6,7 @@ export type ChildWithRelations = Prisma.ChildGetPayload<{
     kostentraeger: true;
     school: { include: { holidayPlan: { include: { holidays: true } } } };
     pool: true;
-    assignments: { include: { user: true } };
+    assignments: { include: { profile: true } };
     schedules: true;
     absences: true;
     vertretungen: { include: { substituteUser: true } };
@@ -21,7 +21,7 @@ const childInclude = {
     },
   },
   pool: true,
-  assignments: { include: { user: true } },
+  assignments: { include: { profile: true } },
   schedules: true,
   absences: true,
   vertretungen: { include: { substituteUser: true } },
@@ -61,7 +61,7 @@ export async function searchAssignedChildrenByName(
   if (trimmed.length < 1) return [];
   return prisma.child.findMany({
     where: {
-      assignments: { some: { userId } },
+      assignments: { some: { profile: { userId } } },
       OR: [
         { firstName: { contains: trimmed } },
         { lastName: { contains: trimmed } },

--- a/src/features/handlungsbedarf/services/index.ts
+++ b/src/features/handlungsbedarf/services/index.ts
@@ -19,14 +19,18 @@ export async function findSickEventsInRange(from: Date, to: Date) {
 
 export async function findAssignmentsByUserIds(userIds: string[]) {
   if (userIds.length === 0) return [];
-  return prisma.childAssignment.findMany({
-    where: { userId: { in: userIds } },
+  const rows = await prisma.childAssignment.findMany({
+    where: { profile: { userId: { in: userIds } } },
     select: {
-      userId: true,
       weekday: true,
       child: { select: { id: true, firstName: true, lastName: true } },
+      profile: { select: { userId: true } },
     },
   });
+  return rows.map(({ profile, ...rest }) => ({
+    ...rest,
+    userId: profile.userId as string,
+  }));
 }
 
 export async function findVertretungenInRange(from: Date, to: Date) {
@@ -107,10 +111,10 @@ export async function findAllSchedulesWithHolidayPlan() {
   });
 }
 
-/** All child→user assignments (weekday-based). Used for unassigned-block detection. */
+/** All child assignments (weekday-based). Used for unassigned-block detection. */
 export async function findAllAssignments() {
   return prisma.childAssignment.findMany({
-    select: { childId: true, weekday: true, userId: true },
+    select: { childId: true, weekday: true },
   });
 }
 

--- a/src/features/timesheet/services/index.ts
+++ b/src/features/timesheet/services/index.ts
@@ -11,7 +11,7 @@ export async function getAssignedChildren(userId: string) {
   // A Schulbegleiter can have multiple ChildAssignment rows for the same
   // child (one per weekday), so we dedupe by child id before returning.
   const rows = await prisma.childAssignment.findMany({
-    where: { userId },
+    where: { profile: { userId } },
     include: { child: true },
     orderBy: { child: { firstName: "asc" } },
   });
@@ -32,7 +32,7 @@ export async function getAssignmentsByWeekday(
   userId: string,
 ): Promise<AssignmentsByWeekday> {
   const rows = await prisma.childAssignment.findMany({
-    where: { userId },
+    where: { profile: { userId } },
     select: { childId: true, weekday: true },
   });
   const result = emptyAssignmentsByWeekday();


### PR DESCRIPTION
## Why

Currently a Schulbegleiter can only be assigned to a child (Zuweisung) **after** they accept their invitation. The reason is structural: `ChildAssignment` had a hard foreign key `userId → User`, and a `User` (auth account) only comes into existence when the assistant accepts the invitation and signs up (better-auth `signUp.email` → the `databaseHooks.user.create.after` hook links the profile and flips status to `ACCEPTED`). Before that only a `SchoolAssistantProfile` exists (`userId = null`), so the assignment dropdown filtered `schoolAssistants.filter((p) => !!p.userId)` — there was nothing for the FK to point at.

## What

Repoint `ChildAssignment` from `User` → `SchoolAssistantProfile`. The **profile is the stable identity** of a Schulbegleiter and exists from creation, regardless of invitation status. This removes the restriction at its root and is semantically correct (a Zuweisung is to a Schulbegleiter, not to a login account).

- Coverage/timesheet/handlungsbedarf queries now reach the account through the `profile → userId` relation, so **accepted assistants are unaffected**.
- Once a pending assistant accepts, their pre-existing assignments light up automatically (the profile gains a `userId`).
- The assignment dropdown (`/admin/children`) now lists **all** Schulbegleiter, accepted or pending.

Rejected alternative: eagerly creating a `User` at profile creation. It would require rewriting the sensitive onboarding/signup flow and risks a security regression — a credential-less `User` could use "forgot password" to bypass the invitation gate.

## Scope carve-out

The **Handlungsbedarf → sick → substitute (Vertretung)** flow still lists only accepted assistants. That's intentional: `ChildVertretung.substituteUserId` is a real `User` FK — a substitute actually performs and signs the work, so they must have an account. This PR changes **Zuweisung**, not **Vertretung**.

## Changes

- **Schema + migration**: `ChildAssignment.userId` → `profileId` (FK to `SchoolAssistantProfile`, `onDelete: Cascade`). The migration backfills existing rows via a `profile.userId` join.
- **Services**: `children`, `timesheet`, `handlungsbedarf` assignment queries filter via `profile: { userId }`; create/update use `profileId`.
- **UI**: removed the `!!userId` filter on the children page; combobox empty text → "Keine Schulbegleiter."; the map's assistant identity uses `profileId`.
- **Seed scripts** updated to assign by profile.

## Migration

Applied automatically on deploy — the container `CMD` runs `npx prisma migrate deploy` before booting the server, so merging to `main` picks it up with no manual step in prod. For local dev, run `npm run db:migrate`.

Note: MySQL has no transactional DDL, so a mid-migration failure would leave the table partially migrated and block later deploys until resolved. Risk here is low — the backfill covers every existing row (each current assignment already points at an accepted assistant whose profile carries that `userId`), so the `DELETE … WHERE profileId IS NULL` safety net should match nothing.

## Verification

`prisma generate` ✓ · `tsc --noEmit` ✓ · `eslint` ✓ · `next build` ✓. Not yet exercised against a live DB. The seed's pending `PENDING_INVITATION` (Daniela Huber) is a ready-made manual test: assign her to a child in `/admin/children`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)