### PR TITLE
fix(handlungsbedarf): show child name instead of raw ID for over-schedule flags

### DIFF
--- a/src/features/handlungsbedarf/facade.ts
+++ b/src/features/handlungsbedarf/facade.ts
@@ -298,9 +298,18 @@ export const HandlungsbedarfFacade = {
 
     // Sum booked WORK minutes per (childId, date). Events without explicit
     // times can't contribute to a duration comparison, so they're skipped.
+    // Also backfill child names from WORK events: a child can have booked hours
+    // without any Schedule row (scheduled = 0), and would otherwise fall back to
+    // the raw childId when flagged below.
     const bookedMinutesByPair = new Map<string, number>();
     for (const w of workEvents) {
       if (!w.childId || !w.startTime || !w.endTime) continue;
+      if (w.child && !childNameById.has(w.childId)) {
+        childNameById.set(
+          w.childId,
+          `${w.child.firstName} ${w.child.lastName}`,
+        );
+      }
       const key = `${w.childId}|${isoDate(w.date)}`;
       const min =
         (bookedMinutesByPair.get(key) ?? 0) +

--- a/src/features/handlungsbedarf/services/index.ts
+++ b/src/features/handlungsbedarf/services/index.ts
@@ -121,7 +121,8 @@ export async function findAllAssignments() {
 /**
  * All WORK events touching a child in the range. Returned with startTime/endTime
  * so the facade can sum daily minutes per (child, date) and compare against
- * Schedule minutes.
+ * Schedule minutes. The child's name is included so the facade can label a
+ * flagged child even when they have no Schedule row (scheduled = 0).
  */
 export async function findChildWorkEventsInRange(from: Date, to: Date) {
   return prisma.event.findMany({
@@ -136,6 +137,7 @@ export async function findChildWorkEventsInRange(from: Date, to: Date) {
       date: true,
       startTime: true,
       endTime: true,
+      child: { select: { firstName: true, lastName: true } },
     },
   });
 }


### PR DESCRIPTION
## Problem

When a Schulbegleiter creates a Vertretung that gets auto-assigned straight away (because the entered name matches an existing child), the resulting `BOOKED_HOURS_OVER_SCHEDULE` case showed up in the **Weitere Fälle** section of the Handlungsbedarf queue with the child's **raw database ID** instead of their name:

> `cmrlpgwa60018o401upmnvy1r` · 15.07.2026 · Über Stundenplan
> 5 h gebucht, Stundenplan sieht 0 min vor (Differenz 5 h).

## Cause

In `HandlungsbedarfFacade.listOtherFlags`, the `childNameById` lookup map was populated **only from `schedules`**. A `BOOKED_HOURS_OVER_SCHEDULE` flag can be emitted for a child that has booked WORK hours but **no Schedule row** (`scheduled = 0`, hence "Stundenplan sieht 0 min vor"). For those children the name lookup missed and the code fell back to rendering the raw `childId`.

## Fix

- `findChildWorkEventsInRange` (service) now selects the child's `firstName`/`lastName`.
- The facade backfills `childNameById` from WORK events, so a flagged child without a Schedule row still resolves to their name.

The existing `?? childId` fallback is kept as a last-resort safety net.

## Notes

- Changes stay within the architecture layers: a dumb `select` addition in the service, name-map population in the facade. No action/use-case/UI changes needed.
- Could not run `tsc`/`eslint` in this environment (no `node_modules`/generated Prisma client present); the change is a small, type-safe select + map population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)