### PR TITLE
feat(timesheet): allow own Krankmeldung for future days

### DIFF
--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -207,6 +207,14 @@ export function NewEntrySheet({
 
   const dateIsWeekend = isWeekend(date);
 
+  const allowFutureDate = type === EventType.SICK && sickTarget === "self";
+
+  useEffect(() => {
+    if (allowFutureDate) return;
+    const today = formatIsoDateUtc(new Date());
+    setDate((cur) => (cur > today ? today : cur));
+  }, [allowFutureDate]);
+
   const canProceed = useMemo(() => {
     if (type === EventType.SICK) {
       // A child sick report submits via its own button, not the form.
@@ -494,7 +502,7 @@ export function NewEntrySheet({
                 id="date"
                 type="date"
                 value={date}
-                max={formatIsoDateUtc(new Date())}
+                max={allowFutureDate ? undefined : formatIsoDateUtc(new Date())}
                 onChange={(e) => setDate(e.target.value)}
               />
             </div>


### PR DESCRIPTION
## What

A Schulbegleiter can now file their **own** sick note (*eigene Krankmeldung*) for a **future** day, not only for today or a past day.

## Why

Previously the date field in the "Neuer Eintrag" sheet was hard-capped at today (`max={today}`), so an SB could not report an upcoming absence in advance (e.g. a planned medical procedure or a doctor's note that covers future days).

## How

`src/features/timesheet/components/new-entry-sheet.tsx`:
- The shared date input's `max` is now lifted only when the selected entry is an **own** sick note (`type === SICK && sickTarget === "self"`).
- A guard clamps a future date back to today if the entry type switches away from an own sick note, so a forward-dated Work or child-sick entry can't slip through the shared field.

## Scope

- **Own sick note** → future dates allowed ✅
- **Work / Vertretung / Indirekt entries** → still capped at today (you can't log work you haven't done)
- **Child sick reports** → still capped at today

No server-side change was required: neither the Zod schema (`CreateEventSchema`, SICK branch) nor `TimesheetFacade.createEvent` restricts SICK dates against today — the future-date block was purely the client-side `max` attribute.

## Testing

The project has no test runner, and dependencies aren't installed in this environment, so no automated checks were run. Change is a small, isolated UI derivation. Manual check: open "Neuer Eintrag" → Krank → *Ich (eigene Krankmeldung)* → the date picker now permits future days; switching back to Arbeit re-caps and clamps the date to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)