### PR TITLE
ci(security): add dependency-vuln gate + digest-pin Docker base images [F-18]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot keeps dependencies and pinned base images patched on a defined
+# cadence (audit finding F-18). npm updates stay ahead of the CI audit gate in
+# .github/workflows/ci.yml; docker updates bump the digest pins in the Dockerfile
+# and docker-compose*.yml files; github-actions keeps workflow actions current.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # Batch low-risk patch/minor bumps into a single PR to cut review noise.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,26 @@ env:
   LOG_PRETTY: "true"
 
 jobs:
+  dependency-audit:
+    name: Dependency Vulnerability Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Fails the build on any high/critical advisory in the committed lockfile.
+      # Reads package-lock.json directly, so no install step is required.
+      # Dependabot (see .github/dependabot.yml) opens patch PRs weekly to keep
+      # dependencies ahead of this gate.
+      - name: Audit dependencies (fail on high/critical)
+        run: npm audit --audit-level=high
+
   lint-and-format:
     name: Lint, Format, and Build
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
+# Base images are pinned by digest for supply-chain integrity (audit finding F-18).
+# The sha256 below is the multi-arch index digest of node:22-alpine, so the build
+# still resolves the correct per-architecture image while the tag stays immutable.
+#
+# Update cadence: Dependabot (docker ecosystem, see .github/dependabot.yml) opens a
+# PR weekly to bump these digests. To update manually, run:
+#   docker buildx imagetools inspect node:22-alpine --format '{{.Manifest.Digest}}'
+# and replace the sha256 on all three FROM lines below.
+
 # ---- Dependencies ----
-FROM node:22-alpine AS deps
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
 # ---- Builder ----
-FROM node:22-alpine AS builder
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -20,7 +29,7 @@ ENV NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=$NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
 RUN npm run build
 
 # ---- Runner ----
-FROM node:22-alpine AS runner
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/docker-compose.feature.yml
+++ b/docker-compose.feature.yml
@@ -18,7 +18,8 @@ services:
              node server.js"
 
   db:
-    image: mysql:8.0
+    # Pinned by digest for supply-chain integrity (F-18); Dependabot bumps it weekly.
+    image: mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-secret}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   db:
-    image: mysql:8.0
+    # Pinned by digest for supply-chain integrity (F-18); Dependabot bumps it weekly.
+    image: mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: lebenshilfe
@@ -26,7 +27,7 @@ services:
       start_period: 10s
 
   mailpit:
-    image: axllent/mailpit
+    image: axllent/mailpit:latest@sha256:5a49a77c5bdbe7c5474450b4f46348d09949df3695257729c93a30369382d4f6
     container_name: mailpit
     ports:
       - "8025:8025"
@@ -37,7 +38,7 @@ services:
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:latest@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     container_name: minio
     ports:
       - "9000:9000"
@@ -48,7 +49,7 @@ services:
     command: server /data --console-address ":9001"
 
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:latest@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       - minio
     entrypoint: >


### PR DESCRIPTION
Implements **[F-18] (COD-114)** — https://linear.app/coding-for-change/issue/COD-114

## Problem

CI ran `npm ci` + format/lint/build but **no dependency vulnerability scan**, so a high/critical advisory would never fail the build. Docker base images (`node:22-alpine`, `mysql:8.0`, and the dev `minio`/`mailpit` images) used **mutable tags** — the runtime image can change underneath us. Both are supply-chain integrity gaps (OWASP A06/A08, ASVS 5.0 V13).

## Changes

- **`.github/workflows/ci.yml`** — new `dependency-audit` job running `npm audit --audit-level=high`, which fails the build on any high/critical advisory. It reads the committed `package-lock.json` directly, so no `npm ci` is needed (fast, runs in parallel with the build job).
- **`Dockerfile`** — all three `node:22-alpine` stages pinned to the multi-arch **index** digest (`@sha256:16e2…`), so per-architecture resolution still works while the reference is immutable. A header comment documents both the Dependabot cadence and the manual `docker buildx imagetools inspect` update path.
- **`docker-compose.yml` / `docker-compose.feature.yml`** — pinned `mysql:8.0` (dev + feature) plus the dev-only `axllent/mailpit`, `minio/minio`, `minio/mc` images by digest. (`docker-compose.prod.yml` is untouched — it references the app's own freshly-built registry image, not a public base image.)
- **`.github/dependabot.yml`** (new) — weekly `npm`, `docker`, and `github-actions` updates. This is the **documented update schedule**: it keeps dependencies ahead of the audit gate and auto-bumps the image digest pins.

## Acceptance criteria

- [x] CI fails on high/critical dependency advisories
- [x] Docker base images pinned by digest; update schedule documented

## Verification

- `npm audit --audit-level=high` → exit 0 on the current lockfile (clean after #141)
- All 5 pinned digests resolve against the registry (`docker buildx imagetools inspect`)
- `ci.yml` + `dependabot.yml` parse as valid YAML; both compose files pass `docker compose config`
- Changed YAML passes `prettier --check`

> Note: branched off `origin/main` **after** #141 (the npm-audit fixes) merged, so the new gate is green from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)