### PR TITLE
ci(deploy): serialize deploys and pin the running image to the commit SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,17 @@ on:
 permissions:
   contents: read
 
+# Serialize deploys. Without this, two merges in quick succession spawn two
+# concurrent deploy runs; whichever finishes its `docker compose up` LAST wins,
+# so a slower-building older commit can clobber a newer one (this happened with
+# PRs #142/#143). The group forces runs to queue instead of racing, and
+# cancel-in-progress:false keeps the running deploy alive while collapsing the
+# queue to the newest pending run — which, on linear main history, contains all
+# prior commits. Net effect: prod always converges on the latest commit.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -90,6 +101,7 @@ jobs:
 
           # Write .env from decrypted secrets and copy to VPS
           printf '%s\n' \
+            "IMAGE_TAG=${{ github.sha }}" \
             "DATABASE_URL=$(jq -r '.DATABASE_URL // empty' decrypted.json)" \
             "BETTER_AUTH_SECRET=$(jq -r '.BETTER_AUTH_SECRET // empty' decrypted.json)" \
             "RESEND_API_KEY=$(jq -r '.RESEND_API_KEY // empty' decrypted.json)" \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,9 @@
 services:
   app:
-    image: localhost:5000/lebenshilfe:latest
+    # Pinned to the exact commit that was deployed (see deploy.yml, which writes
+    # IMAGE_TAG=<git sha> into .env). Falls back to :latest for manual `docker
+    # compose up` on the VPS.
+    image: localhost:5000/lebenshilfe:${IMAGE_TAG:-latest}
     labels:
       alloy-logging: true
     restart: unless-stopped


### PR DESCRIPTION
## Background

While debugging why the [#142](https://github.com/coding-for-change/lebenshilfe/pull/142) Handlungsbedarf fix appeared not to work in production, the root cause turned out to be the **deploy pipeline**, not the code. The fix was correct and merged — but prod briefly ran an image that predated it.

## The race

Every deploy tags & pushes the **mutable `:latest`** and then runs `docker compose pull && docker compose up -d` on the VPS. Two merges in quick succession spawn two concurrent Deploy runs, and **whichever finishes its `up` last wins — regardless of which commit is newer.**

On 2026-07-15:

| Deploy | Commit | Has #142 fix? | `up -d` ran at |
|---|---|---|---|
| #142 (the fix) | `cb1280c` | ✅ | ~06:45:42 |
| #143 (krankmeldung) | `9452394` | ❌ | **~06:46:02 — finished last** |
| #141 | `5a990fb` | ✅ | ~06:55:20 |

#143 started 12s *before* #142 but built slower, so its deploy finished ~20s **after** and re-published a pre-fix `:latest`. Prod ran without the fix for ~9 minutes until the next deploy restored it.

## The fix

Two complementary changes:

1. **`concurrency` group (`cancel-in-progress: false`)** — the real fix. Deploy runs now queue instead of racing. The in-flight deploy is left alive and the pending queue collapses to the newest run, which on linear `main` history already contains every prior commit. Net effect: **prod always converges on the tip of `main`**, never an older commit. Skipped intermediate deploys are safe — `prisma migrate deploy` at container start applies all pending migrations, and the tip build includes all prior code.

2. **Pin the container to `:${IMAGE_TAG}` (the git SHA)** instead of `:latest`. The deploy writes `IMAGE_TAG=<sha>` into the VPS `.env`; `docker-compose.prod.yml` reads `${IMAGE_TAG:-latest}`. Each deploy runs exactly the image it built — immutable, reproducible, and immune to pull-through-cache staleness on `:latest`. Manual `docker compose up` on the box still falls back to `:latest`.

## Verification

- `deploy.yml` parses as valid YAML; `concurrency` block confirmed.
- `docker compose config` resolves the image both ways:
  - `IMAGE_TAG=abc123sha` → `localhost:5000/lebenshilfe:abc123sha`
  - unset → `localhost:5000/lebenshilfe:latest`
- `:latest` is still built and pushed, so nothing else that references it breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)