### PR TITLE
fix: auto-refresh content on resume so home-screen users see the latest data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { MapsConsentProvider } from "@/lib/maps/maps-consent";
+import { AutoRefresh } from "@/components/auto-refresh";
 import { getSession } from "@/lib/auth-guards";
 import { ConsentFacade } from "@/features/consent";
 import { setMapsConsentAction } from "@/features/consent/actions";
@@ -58,6 +59,10 @@ export default async function RootLayout({
       className={`${inter.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col font-sans">
+        {/* Keeps content fresh on resume/poll — critical for the standalone
+            iOS home-screen app, which has no reload UI and freezes on
+            background. */}
+        <AutoRefresh />
         <MapsConsentProvider
           initialConsent={initialConsent}
           authenticated={!!session}

--- a/src/components/auto-refresh.tsx
+++ b/src/components/auto-refresh.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+// Re-pulls the current route's server-rendered content so users see changes
+// admins made without a manual refresh.
+//
+// This matters most for the iOS home-screen (standalone) app: it has no reload
+// UI, and iOS *freezes* its page when backgrounded — so returning to it would
+// otherwise show whatever was on screen when the user left, indefinitely. We
+// use `router.refresh()` (not a full reload) so client state — open sheets,
+// form inputs, scroll position — is preserved while the server data updates.
+//
+// Renders nothing; mounted once in the root layout so it covers every route.
+
+// How often to re-fetch while the app is open and in the foreground.
+const POLL_INTERVAL_MS = 60_000;
+
+export function AutoRefresh() {
+  const router = useRouter();
+
+  useEffect(() => {
+    let lastRefresh = Date.now();
+
+    const refresh = () => {
+      lastRefresh = Date.now();
+      router.refresh();
+    };
+
+    // User returned to the app (tab re-focus, app switch, device unlock).
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+
+    // Page restored from the back/forward (bfcache): its JS was frozen, so the
+    // DOM is stale until we re-fetch.
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) refresh();
+    };
+
+    // Poll only while visible — timers are suspended in the background anyway,
+    // and this spares the server when nobody is looking. The elapsed-time guard
+    // avoids a redundant fetch right after a resume-triggered refresh.
+    const poll = window.setInterval(() => {
+      if (
+        document.visibilityState === "visible" &&
+        Date.now() - lastRefresh >= POLL_INTERVAL_MS
+      ) {
+        refresh();
+      }
+    }, POLL_INTERVAL_MS);
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("pageshow", onPageShow);
+
+    return () => {
+      window.clearInterval(poll);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("pageshow", onPageShow);
+    };
+  }, [router]);
+
+  return null;
+}


### PR DESCRIPTION
## Problem

Since the site launches **standalone** on the iOS home screen (`apple-mobile-web-app-capable`, added in #140), it runs as a chrome-less app. That means:

- **No way to refresh manually** — there's no address bar, reload button, or pull-to-refresh in standalone mode.
- **Stale content on resume** — iOS *freezes* the page when the app is backgrounded. If the user switches away and comes back without fully closing it (swipe-up), iOS restores the frozen page and never re-fetches, so changes admins made never appear.

This also hurts ordinary browser users: anyone who doesn't manually refresh keeps seeing old data.

There is **no service worker** in the app, so this is purely iOS's standalone-app / bfcache behavior — not a cache we need to bust.

## Fix

A small `AutoRefresh` client component, mounted once in the root layout so it covers every route:

- **On resume** → `router.refresh()` when the document becomes visible again (app switch, device unlock, tab re-focus), and on bfcache restore (`pageshow.persisted`).
- **Periodic poll** → `router.refresh()` every ~60s while the app is visible, so a session left open updates on its own. Polling is skipped while backgrounded, and an elapsed-time guard avoids a redundant fetch right after a resume refresh.

It uses `router.refresh()` (the app's existing pattern for re-pulling server data) rather than a full reload, so **client state is preserved** — open sheets, form inputs, and scroll position survive the refresh while the server-rendered content updates.

```
hidden ──▶ visible   → refresh ✓   (user returns to the app)
open & visible       → refresh every ~60s ✓
backgrounded         → polling paused
bfcache restore      → refresh ✓
```

## Verification

- `next dev`: `/login` renders `200`, the `auto-refresh` client chunk is bundled into the page, and the dev log is clean (no hydration errors/warnings).
- `eslint`, `prettier --check`, and `tsc --noEmit` all pass for the changed files.

> The interactive resume/visibility/poll behavior can't be exercised in a headless environment (no browser automation is set up in this repo), so it was verified by a real render + no hydration errors + code review of the standard `visibilitychange` / `pageshow` / `setInterval` wiring. Worth a quick manual check on a physical iPhone (add to home screen → change data as admin → switch away and back → content updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)