### PR TITLE
ci(security): validate Docker image build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,21 @@ jobs:
       - name: Audit dependencies (fail on high/critical)
         run: npm audit --audit-level=high
 
+  docker-build:
+    name: Docker Image Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Builds the image end-to-end so the digest-pinned base images (and any
+      # Dockerfile change) are validated before merge — in particular this
+      # exercises Dependabot's weekly digest bumps. The image is built but never
+      # pushed or deployed.
+      - name: Build Docker image
+        run: docker build -t lebenshilfe:ci .
+
   lint-and-format:
     name: Lint, Format, and Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #144 (F-18 / COD-114). That PR added the `npm audit` gate, digest-pinned the Docker base images, and enabled Dependabot — but it merged **before** this `docker-build` job was added, so `main`'s CI does not currently build the Docker image.

## Why this matters

CI builds the app with `next build`, not `docker build`. So a change to the `Dockerfile` — including **Dependabot's weekly base-image digest bumps** — is never exercised in PR checks and only surfaces at deploy time. Concretely, the open Dependabot PR bumping `node:22-alpine` → `node:26-alpine` shows green today precisely because nothing builds the image.

## Change

Adds a `docker-build` job to `.github/workflows/ci.yml` that builds the image end-to-end (no push, no deploy). Any `Dockerfile` change — digest bump, base-image change, layer edit — now has to actually build before it can be merged.

## Verification

- `docker build` succeeds locally against the current digest-pinned `Dockerfile` (image builds clean).
- `ci.yml` parses as valid YAML and passes `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)