### PR TITLE
fix(timesheet): stop profile text overflowing the settings dialog on mobile

### DIFF
--- a/src/features/timesheet/components/settings-dialog.tsx
+++ b/src/features/timesheet/components/settings-dialog.tsx
@@ -61,7 +61,7 @@ export function SettingsDialog({ open, onOpenChange, name, email }: Props) {
           <DialogTitle>Einstellungen</DialogTitle>
           <DialogDescription>Profil und Konto verwalten.</DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col md:h-[34rem] md:flex-row">
+        <div className="flex min-w-0 flex-col md:h-[34rem] md:flex-row">
           <aside className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted/40 p-3 md:w-56 md:border-b-0 md:border-r">
             <div className="px-2 pb-2 pt-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Einstellungen
@@ -86,7 +86,7 @@ export function SettingsDialog({ open, onOpenChange, name, email }: Props) {
             </nav>
           </aside>
 
-          <div className="flex-1 overflow-y-auto p-6">
+          <div className="min-w-0 flex-1 overflow-y-auto p-6">
             {section === "profil" && (
               <div className="space-y-6">
                 <div>
@@ -96,7 +96,7 @@ export function SettingsDialog({ open, onOpenChange, name, email }: Props) {
                   </p>
                 </div>
                 <div className="flex items-center gap-4 rounded-xl border border-border bg-muted/30 p-4">
-                  <div className="grid size-14 place-items-center rounded-full bg-gradient-to-br from-amber-400/80 to-rose-500/60 text-lg font-semibold text-white">
+                  <div className="grid size-14 shrink-0 place-items-center rounded-full bg-gradient-to-br from-amber-400/80 to-rose-500/60 text-lg font-semibold text-white">
                     {initials}
                   </div>
                   <div className="min-w-0">


### PR DESCRIPTION
## Problem

On mobile, opening the Schulbegleiter **Einstellungen → Profil** dialog let the email address (and the footer note) overflow off the right edge — the email was hard-clipped with **no ellipsis**:

> `alexander.reyers@codingforchange.c` ⟶ runs off screen

## Cause

`DialogContent` is `display: grid`, and the two elements between it and the profile card — the flex-col wrapper (a grid item) and the `flex-1` content column (a flex item) — had **no `min-w-0`**. Grid/flex items default to `min-width: auto` (= min-content), so the column refused to shrink below the width of the unbreakable email string. It expanded past the dialog, and `overflow-x: hidden` on `DialogContent` then hard-clipped everything. The `truncate` already on the email never got a bounded width to work against, so no ellipsis appeared, and the plain footer paragraph laid out at the over-wide width instead of wrapping.

## Fix

Add `min-w-0` to the wrapper and the content column so they shrink to the dialog width. With a bounded width, the existing `truncate` renders an ellipsis and normal text wraps. Also add `shrink-0` to the avatar so it stays circular when space is tight.

```diff
-<div className="flex flex-col md:h-[34rem] md:flex-row">
+<div className="flex min-w-0 flex-col md:h-[34rem] md:flex-row">
 ...
-  <div className="flex-1 overflow-y-auto p-6">
+  <div className="min-w-0 flex-1 overflow-y-auto p-6">
 ...
-    <div className="grid size-14 place-items-center rounded-full ...">
+    <div className="grid size-14 shrink-0 place-items-center rounded-full ...">
```

## Verification

Rendered a static replica of the dialog DOM (same classes) at 390px width with a headless browser:

- **Before:** email hard-cut with no ellipsis; footer note clipped mid-word.
- **After:** email truncates with `…`, card stays inside the dialog, footer note wraps to a second line.

Desktop (`md:` row layout) is unaffected — `min-w-0` only matters once space is constrained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)