### PR TITLE
fix: recover from stale Server Action after deploy (without losing form data)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -8,14 +9,56 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, RefreshCw } from "lucide-react";
+import {
+  isServerActionNotFoundError,
+  reloadForNewDeployment,
+} from "@/lib/deployment-skew";
 
 export default function GlobalError({
+  error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // A stale Server Action (tab built by a previous deployment) cannot be
+  // recovered by reset() — that re-renders the same client tree, which still
+  // references the missing action ID. Only a full reload fetches the new build.
+  const isStaleDeployment = isServerActionNotFoundError(error);
+
+  useEffect(() => {
+    if (isStaleDeployment) reloadForNewDeployment();
+  }, [isStaleDeployment]);
+
+  if (isStaleDeployment) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center p-6 md:p-10">
+        <Card className="w-full max-w-md border-border/60 shadow-xl">
+          <CardHeader className="gap-2 text-center">
+            <div className="mx-auto flex size-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <RefreshCw className="size-6 animate-spin" />
+            </div>
+            <CardTitle className="text-xl font-semibold">
+              Neue Version verfügbar
+            </CardTitle>
+            <CardDescription>
+              Die Seite wird neu geladen, um die neueste Version zu laden…
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <Button
+              onClick={() => window.location.reload()}
+              variant="default"
+            >
+              Jetzt neu laden
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-[50vh] flex-col items-center justify-center p-6 md:p-10">
       <Card className="w-full max-w-md border-border/60 shadow-xl">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { MapsConsentProvider } from "@/lib/maps/maps-consent";
 import { AutoRefresh } from "@/components/auto-refresh";
+import { DeploymentUpdateNotice } from "@/components/deployment-update-notice";
 import { getSession } from "@/lib/auth-guards";
 import { ConsentFacade } from "@/features/consent";
 import { setMapsConsentAction } from "@/features/consent/actions";
@@ -63,6 +64,9 @@ export default async function RootLayout({
             iOS home-screen app, which has no reload UI and freezes on
             background. */}
         <AutoRefresh />
+        {/* Prompts a reload when a Server Action fails because the tab was
+            built by a previous deployment (stale action IDs). */}
+        <DeploymentUpdateNotice />
         <MapsConsentProvider
           initialConsent={initialConsent}
           authenticated={!!session}

--- a/src/components/deployment-update-notice.tsx
+++ b/src/components/deployment-update-notice.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { isServerActionNotFoundError } from "@/lib/deployment-skew";
+
+/**
+ * Mounted once in the root layout. When a Server Action fails because the tab
+ * was built by a previous deployment (see lib/deployment-skew), we show a
+ * persistent banner asking the user to reload, rather than reloading for them.
+ *
+ * Why a prompt and not an automatic reload: on this path the error surfaces as
+ * an unhandled rejection from an event handler (e.g. a form submit), so the
+ * form is still mounted and holds the user's input. Reloading automatically
+ * would discard that input. The banner lets the user finish or copy their work
+ * and reload when ready. The error-boundary case (app/error.tsx), where the
+ * form has already been unmounted and there is nothing left to lose, reloads
+ * automatically instead.
+ */
+export function DeploymentUpdateNotice() {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  useEffect(() => {
+    function handle(error: unknown) {
+      if (isServerActionNotFoundError(error)) setUpdateAvailable(true);
+    }
+    function onRejection(event: PromiseRejectionEvent) {
+      handle(event.reason);
+    }
+    function onError(event: ErrorEvent) {
+      handle(event.error);
+    }
+    window.addEventListener("unhandledrejection", onRejection);
+    window.addEventListener("error", onError);
+    return () => {
+      window.removeEventListener("unhandledrejection", onRejection);
+      window.removeEventListener("error", onError);
+    };
+  }, []);
+
+  if (!updateAvailable) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="fixed inset-x-0 bottom-0 z-50 flex justify-center p-4"
+    >
+      <div className="flex w-full max-w-2xl flex-col gap-3 rounded-lg border border-border/60 bg-background/95 p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <RefreshCw className="size-4" />
+          </div>
+          <div className="text-sm">
+            <p className="font-medium">Eine neue Version ist verfügbar</p>
+            <p className="text-muted-foreground">
+              Bitte laden Sie die Seite neu, um fortzufahren. Ungespeicherte
+              Eingaben in Formularen gehen dabei verloren.
+            </p>
+          </div>
+        </div>
+        <Button
+          onClick={() => window.location.reload()}
+          className="shrink-0"
+        >
+          Neu laden
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/deployment-skew.ts
+++ b/src/lib/deployment-skew.ts
@@ -1,0 +1,68 @@
+/**
+ * Deployment skew: recovering from stale Server Action IDs.
+ *
+ * Each Server Action is identified by an action ID baked into the build. A new
+ * deployment generates new IDs (Next rotates them at least every 14 days even
+ * when the source is unchanged), so a tab still running a previous build can
+ * POST an action ID that no longer exists on the server. Next then throws a
+ * client-side `UnrecognizedActionError` and the user is stuck until they
+ * manually refresh — which is not obvious to them.
+ *
+ * A full page reload always recovers (it fetches the current build), so we
+ * detect this specific error and reload automatically. See
+ * node_modules/next/dist/docs/01-app/02-guides/server-actions.md ("Deployment
+ * considerations").
+ */
+
+// Next tags the thrown error with this stable, non-enumerable code (see
+// server-action-reducer.js in the Next runtime). Matching the code first keeps
+// detection robust against production message redaction and translation.
+const NEXT_ACTION_NOT_FOUND_CODE = "E715";
+
+/**
+ * True when `error` is Next's "Server Action was not found on the server"
+ * error, i.e. the running tab was built by a previous deployment.
+ */
+export function isServerActionNotFoundError(error: unknown): boolean {
+  if (error == null || typeof error !== "object") return false;
+
+  if (
+    (error as { __NEXT_ERROR_CODE?: unknown }).__NEXT_ERROR_CODE ===
+    NEXT_ACTION_NOT_FOUND_CODE
+  ) {
+    return true;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  return (
+    typeof message === "string" &&
+    (/was not found on the server/i.test(message) ||
+      /Failed to find Server Action/i.test(message))
+  );
+}
+
+// Reload at most once per this window, so a genuinely persistent error (an
+// actual bug rather than deployment skew) can't put the tab in a reload loop.
+const RELOAD_GUARD_KEY = "deploy-skew-reloaded-at";
+const RELOAD_GUARD_WINDOW_MS = 10_000;
+
+/**
+ * Reload the page so the tab picks up the current deployment. No-op outside the
+ * browser, outside production (never interfere with `next dev`), and if we
+ * already reloaded within the guard window.
+ */
+export function reloadForNewDeployment(): void {
+  if (typeof window === "undefined") return;
+  if (process.env.NODE_ENV !== "production") return;
+
+  try {
+    const last = Number(window.sessionStorage.getItem(RELOAD_GUARD_KEY));
+    if (last && Date.now() - last < RELOAD_GUARD_WINDOW_MS) return;
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+  } catch {
+    // sessionStorage can throw (private mode, disabled storage). Reloading once
+    // is still better than leaving the user stuck, so fall through.
+  }
+
+  window.location.reload();
+}


### PR DESCRIPTION
## Problem

When you deploy while someone has the app open, their tab still holds Server Action IDs from the **previous** build. The next action they invoke fails with Next's *"Failed to find Server Action… older or newer deployment"* error, and they're stuck hitting it repeatedly — with no indication that a refresh fixes it.

Per this Next version's own docs (`server-actions.md` → *Deployment considerations*), action IDs rotate on every deploy (and at least every 14 days even with unchanged source), so for a self-hosted single-container app this **can't be fully prevented**. The documented mitigation is to *"surface the error as a retry path… so a refresh recovers the user."*

## Approach

Detection keys off Next's **stable client-side error code `E715`** (with a message fallback), so it survives production error redaction — no blind reloading on unrelated errors, and no reload loops.

The error reaches the client two ways, and the **data-loss risk differs**, so they're handled differently:

| Path | State of the form | Behavior |
|------|-------------------|----------|
| **`unhandledrejection`** (action awaited in an event handler — the common case) | Form still mounted, **user input intact** | Show a persistent **"new version — reload"** banner. The user reloads when *they're* ready, so **their form data is never discarded behind their back**. |
| **Error boundary** (`app/error.tsx`) | React already unmounted the subtree — form is gone | Reload automatically (nothing left to lose; `reset()` can't help — it re-renders the same stale action reference). |

This directly answers the two concerns raised: users no longer get stuck not knowing to refresh, **and** a half-filled form isn't wiped by a surprise reload.

## Safety

- Auto-reload is gated to `NODE_ENV === "production"` (never interferes with `next dev`; still covers prod + feature deploys).
- Rate-limited via `sessionStorage` (max one auto-reload per 10s) so a genuinely persistent error can't cause a reload loop.
- Independent of the existing `AutoRefresh` component (that does soft `router.refresh()` for data freshness; it can't fix stale action IDs because it doesn't re-fetch the client bundle).

## Files

- `src/lib/deployment-skew.ts` — pure `isServerActionNotFoundError()` detector + guarded `reloadForNewDeployment()`.
- `src/components/deployment-update-notice.tsx` — global listener + reload banner, mounted in the root layout.
- `src/app/error.tsx` — detects the stale-action error and auto-reloads (boundary path).
- `src/app/layout.tsx` — mounts the notice.

## Verification

- `tsc --noEmit` clean, `next build` succeeds, `prettier --check` clean on all changed files.
- Detection is code-based (`E715`), matching how the Next runtime throws it (`server-action-reducer.js`).

## Optional follow-ups (not in this PR)

- Set a stable `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` in the deploy env — good hygiene for closure-encrypted args (esp. if the app ever runs multiple replicas); it does **not** fix action-ID rotation on its own.
- Rolling deploys instead of the current `docker compose up -d` cutover would shrink (not eliminate) the skew window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)