### PR TITLE
fix(timesheet): show full entry titles on mobile day view

### DIFF
--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -648,7 +648,7 @@ export function TabDay({
               >
                 <div className="flex items-center gap-3">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium truncate">{title}</p>
+                    <p className="font-medium break-words">{title}</p>
                     <div className="flex flex-wrap items-center gap-2 mt-1 text-xs text-muted-foreground">
                       <Badge
                         variant="secondary"


### PR DESCRIPTION
## Problem
In the mobile **Tag** (day) view, work-entry titles were rendered with `truncate`, which forces `white-space: nowrap` and an ellipsis. Names like *"Testkind Alex R 2"* got clipped to *"Testkind Alex …"* even though the card had plenty of room.

## Fix
The title sits in a `min-w-0 flex-1` column, so it can safely wrap. Swapped `truncate` for `break-words` on the title `<p>` in `src/features/timesheet/components/tab-day.tsx`:

```diff
- <p className="font-medium truncate">{title}</p>
+ <p className="font-medium break-words">{title}</p>
```

Long titles now wrap onto a second line and render in full; the time and **Löschen** action stay pinned to the right. `break-words` also handles any unusually long single token.

## Scope
Only the WORK/INDIRECT entry cards used truncation. The other cards in this view (Vertretung, Stundenplan) already stack their text vertically and were unaffected.

## Verification
- `eslint` on the changed file: clean.
- Compiled the class through the project's Tailwind (v4.3.2 engine) to confirm `.break-words { overflow-wrap: break-word }` is generated — the utility survived the v4 renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)