### PR TITLE
fix: detect stale Server Action via response header (banner now actually fires)

### DIFF
--- a/src/components/deployment-update-notice.tsx
+++ b/src/components/deployment-update-notice.tsx
@@ -5,35 +5,46 @@ import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { isServerActionNotFoundError } from "@/lib/deployment-skew";
 
+// Response header Next sets when a Server Action ID no longer exists on the
+// server (i.e. the tab was built by a previous deployment).
+const ACTION_NOT_FOUND_HEADER = "x-nextjs-action-not-found";
+
 /**
- * Mounted once in the root layout. When a Server Action fails because the tab
- * was built by a previous deployment (see lib/deployment-skew), we show a
- * persistent banner asking the user to reload, rather than reloading for them.
- *
- * Why a prompt and not an automatic reload: on this path the error surfaces as
- * an unhandled rejection from an event handler (e.g. a form submit), so the
- * form is still mounted and holds the user's input. Reloading automatically
- * would discard that input. The banner lets the user finish or copy their work
- * and reload when ready. The error-boundary case (app/error.tsx), where the
- * form has already been unmounted and there is nothing left to lose, reloads
- * automatically instead.
+ * Prompts a reload when a Server Action fails because the tab is from an older
+ * deployment. Detection wraps fetch to read the response header rather than
+ * relying on thrown errors, which call sites usually catch and swallow. We
+ * prompt instead of reloading so in-progress form input isn't lost.
  */
 export function DeploymentUpdateNotice() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
 
   useEffect(() => {
-    function handle(error: unknown) {
-      if (isServerActionNotFoundError(error)) setUpdateAvailable(true);
-    }
+    const nativeFetch = window.fetch;
+    const wrappedFetch: typeof window.fetch = async (...args) => {
+      const response = await nativeFetch.apply(window, args);
+      try {
+        if (response.headers.get(ACTION_NOT_FOUND_HEADER) === "1") {
+          setUpdateAvailable(true);
+        }
+      } catch {
+        // Detection must never break the request.
+      }
+      return response;
+    };
+    window.fetch = wrappedFetch;
+
+    // Backup for the call sites that re-throw instead of catching.
     function onRejection(event: PromiseRejectionEvent) {
-      handle(event.reason);
+      if (isServerActionNotFoundError(event.reason)) setUpdateAvailable(true);
     }
     function onError(event: ErrorEvent) {
-      handle(event.error);
+      if (isServerActionNotFoundError(event.error)) setUpdateAvailable(true);
     }
     window.addEventListener("unhandledrejection", onRejection);
     window.addEventListener("error", onError);
+
     return () => {
+      if (window.fetch === wrappedFetch) window.fetch = nativeFetch;
       window.removeEventListener("unhandledrejection", onRejection);
       window.removeEventListener("error", onError);
     };
@@ -45,7 +56,7 @@ export function DeploymentUpdateNotice() {
     <div
       role="alert"
       aria-live="assertive"
-      className="fixed inset-x-0 bottom-0 z-50 flex justify-center p-4"
+      className="fixed inset-x-0 bottom-0 z-[100] flex justify-center p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)]"
     >
       <div className="flex w-full max-w-2xl flex-col gap-3 rounded-lg border border-border/60 bg-background/95 p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-start gap-3">
@@ -62,7 +73,8 @@ export function DeploymentUpdateNotice() {
         </div>
         <Button
           onClick={() => window.location.reload()}
-          className="shrink-0"
+          size="lg"
+          className="w-full shrink-0 sm:w-auto"
         >
           Neu laden
         </Button>


### PR DESCRIPTION
Follow-up to #161. That PR's banner **never showed in practice** — you deployed, then deployed again, and actions kept failing until the 60s `AutoRefresh` forced a reload. This fixes the detection.

## Why #161 didn't fire

It relied on the stale-action error surfacing as an `unhandledrejection` or reaching the `error.tsx` boundary. But the codebase catches the error at the call site and shows a `toast.error(...)` **without re-throwing** — **69 catch blocks vs. only 14 re-throws**. The error was swallowed before either hook could see it, so the tab stayed broken until `AutoRefresh`'s 60s `router.refresh()` happened to force a hard navigation.

## The fix: detect at the network layer

Wrap `window.fetch` and watch responses for the **`x-nextjs-action-not-found`** header, which the Next server sets (with a 404) on every stale-action response — *before* the app's `try/catch` ever runs. This is independent of how each call site handles the error, so it catches all of them.

- Original `fetch` is bound to `window` and restored on unmount; header reads are wrapped in `try/catch` so detection can never interfere with the actual request.
- The `unhandledrejection` / `error` listeners are kept as secondary coverage for the re-throw paths.
- Still a **prompt, not an auto-reload** on this path, so in-progress form input is never discarded (per the earlier discussion). The boundary path in `error.tsx` still auto-reloads (form already gone).

## Mobile (the environment you tested)

- Banner sits **above dialogs** (`z-100`) — the failing action is often triggered from a confirm modal, so it must render over it.
- Respects the **iOS safe-area inset** so it clears the home indicator.
- Full-width **`lg` tap target**. This matters most for the standalone home-screen app, which has no browser reload UI — the button is the only quick recovery.

## Verification

- `tsc --noEmit` clean, `next build` succeeds, `prettier --check` clean.
- Mechanism traced through the Next runtime: server sets the header (`action-handler.ts`), client reducer keys off the same header (`server-action-reducer.js`).

### How to confirm end-to-end
Because the fix must be *in the running build* to help, it can only be verified from a build that includes it: deploy this, open a tab, deploy again, then trigger any action — the banner should appear immediately instead of after 60s. (Tabs already open from before this deploy won't benefit — that's inherent.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)