### PR TITLE
fix: show deploy-skew banner on any failed action POST (500 decryption case)

### DIFF
--- a/src/components/deployment-update-notice.tsx
+++ b/src/components/deployment-update-notice.tsx
@@ -9,11 +9,39 @@ import { isServerActionNotFoundError } from "@/lib/deployment-skew";
 // server (i.e. the tab was built by a previous deployment).
 const ACTION_NOT_FOUND_HEADER = "x-nextjs-action-not-found";
 
+// Request header present on every Server Action dispatch.
+const ACTION_REQUEST_HEADER = "next-action";
+
+// A Server Action POST that returns non-OK after a deploy is version skew: the
+// action ID rotated (404) or its encrypted closure args can't be decrypted by
+// the new build (500). Either way the tab must reload to get the new build.
+function isServerActionRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): boolean {
+  try {
+    if (input instanceof Request && input.headers.has(ACTION_REQUEST_HEADER)) {
+      return true;
+    }
+  } catch {
+    // ignore malformed input
+  }
+  const headers = init?.headers;
+  if (!headers) return false;
+  if (headers instanceof Headers) return headers.has(ACTION_REQUEST_HEADER);
+  if (Array.isArray(headers)) {
+    return headers.some(([key]) => key.toLowerCase() === ACTION_REQUEST_HEADER);
+  }
+  return Object.keys(headers).some(
+    (key) => key.toLowerCase() === ACTION_REQUEST_HEADER,
+  );
+}
+
 /**
  * Prompts a reload when a Server Action fails because the tab is from an older
- * deployment. Detection wraps fetch to read the response header rather than
- * relying on thrown errors, which call sites usually catch and swallow. We
- * prompt instead of reloading so in-progress form input isn't lost.
+ * deployment. Detection wraps fetch to inspect the response (status + header)
+ * rather than relying on thrown errors, which call sites usually catch and
+ * swallow. We prompt instead of reloading so in-progress form input isn't lost.
  */
 export function DeploymentUpdateNotice() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
@@ -23,9 +51,10 @@ export function DeploymentUpdateNotice() {
     const wrappedFetch: typeof window.fetch = async (...args) => {
       const response = await nativeFetch.apply(window, args);
       try {
-        if (response.headers.get(ACTION_NOT_FOUND_HEADER) === "1") {
-          setUpdateAvailable(true);
-        }
+        const notFound = response.headers.get(ACTION_NOT_FOUND_HEADER) === "1";
+        const actionFailed =
+          !response.ok && isServerActionRequest(args[0], args[1]);
+        if (notFound || actionFailed) setUpdateAvailable(true);
       } catch {
         // Detection must never break the request.
       }


### PR DESCRIPTION
Follow-up to #163. You confirmed the banner fires for the console test (bogus action ID → 404 + `x-nextjs-action-not-found`), but a **real deploy still showed nothing** (and no console error). This fixes that gap.

## Root cause of the miss

The console test produced the **404 + not-found header** path, which #163 detects. But a real deploy usually fails differently:

- The app doesn't set `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`, so **every build generates a new key**.
- A stale tab calls an action with closure args encrypted by the *old* key; the new server can't decrypt them and returns **HTTP 500** ("Invalid Server Actions request" — confirmed `res.statusCode = 500` in `action-handler.js`), with **no** not-found header.
- #163 only looked for the header, so it saw nothing. And because your call sites catch the error into a toast without re-throwing, there was nothing in the console either.

## Fix

Broaden detection: any POST carrying the **`next-action`** request header that comes back **non-OK** is treated as deploy skew — covering both `404` (rotated action ID) and `500` (undecryptable args).

- Scoped to action requests via the request header, so navigation/RSC fetches and successful actions never trigger it.
- Successful responses short-circuit before the check (no overhead).
- Everything else (prompt-don't-reload, mobile styling, boundary path) is unchanged from #163.

## Verified
`tsc` clean, `next build` succeeds, `prettier` clean.

## ⚠️ Recommended root-cause fix (separate, needs a secret)

This makes the banner *reliable*, but the underlying pain — skew on **every** deploy — comes from the rotating encryption key. Setting a **stable `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`** across builds would let unchanged actions keep working across deploys, so most deploys wouldn't break stale tabs at all (the banner becomes a rare fallback for deploys that actually change action code). I can wire the plumbing (build arg + runtime env) in a follow-up; you'd add the secret to the Ansible vault. Details in the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)