### PR TITLE
fix(timesheet): give the mobile entry title its own line

### DIFF
--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -646,10 +646,15 @@ export function TabDay({
                 key={ev.id}
                 className="p-4"
               >
-                <div className="flex items-start gap-3">
-                  <div className="flex-1 min-w-0">
-                    <p className="font-medium break-words">{title}</p>
-                    <div className="flex flex-wrap items-center gap-2 mt-1 text-xs text-muted-foreground">
+                <div>
+                  {/* Title owns the full top line so long names never wrap
+                      into the time/action; the meta row sits below it. */}
+                  <p className="font-medium break-words">{title}</p>
+                  <div className="mt-2 flex items-center gap-3">
+                    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <span className="font-mono tabular-nums">
+                        {ev.startTime}–{ev.endTime}
+                      </span>
                       <Badge
                         variant="secondary"
                         className="font-mono"
@@ -681,29 +686,27 @@ export function TabDay({
                           <Badge variant="outline">Mehrere Kinder</Badge>
                         )}
                     </div>
-                    {hint && (
-                      <p className="mt-1 text-xs font-medium text-amber-700">
-                        inkl. {hint.label} · {hint.billed}
-                      </p>
-                    )}
-                    {ev.note && (
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        {ev.note}
-                      </p>
+                    {canDelete(ev) && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleDelete(ev.id)}
+                        disabled={busyId === ev.id}
+                        className="shrink-0"
+                      >
+                        Löschen
+                      </Button>
                     )}
                   </div>
-                  <span className="font-mono text-sm tabular-nums text-muted-foreground">
-                    {ev.startTime}–{ev.endTime}
-                  </span>
-                  {canDelete(ev) && (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => handleDelete(ev.id)}
-                      disabled={busyId === ev.id}
-                    >
-                      Löschen
-                    </Button>
+                  {hint && (
+                    <p className="mt-1 text-xs font-medium text-amber-700">
+                      inkl. {hint.label} · {hint.billed}
+                    </p>
+                  )}
+                  {ev.note && (
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {ev.note}
+                    </p>
                   )}
                 </div>
               </Card>


### PR DESCRIPTION
Re-applies the Option B layout onto the current `main`.

**Context:** PR #164 was merged, but it landed the interim `items-start` commit (title still wraps into the time/action) rather than the intended restructure — the merge captured the branch tip before the final force-push. So `main` currently has the layout that was rejected in review. This PR puts the correct layout on top of current `main` (cuts cleanly, no conflict).

## Problem
On a phone the day-view entry title can't share one line with **both** the full time (`08:00–13:00`) and the text "Löschen" button — the row leaves the title only ~135px, so long names truncate or wrap awkwardly.

## Fix
The **title now owns its own full-width top line**; the time moves down onto the meta row next to the duration/status badges, with **Löschen** aligned right:

```
Testkind Alex R 2
08:00–13:00  5h  Signiert            Löschen
```

Everything stays inside one wrapper `div` (the `Card` is a `flex-col gap-6`, so extra direct children would pick up a 24px gap) with `mt-*` spacing.

## Result
Realistic child names now render in full on a single line — including `Indirekt — Testkind Alex R 2`, which previously wrapped. Only genuinely extreme names wrap, and the card degrades cleanly.

## Verification
Rendered the layout at 375px (the width where the title originally truncated) using the project's compiled Tailwind theme and the real `Card`/`Badge`/`Button` classes, screenshotted with a headless browser — all realistic titles fit on one line and the meta row + Löschen align correctly. `eslint` on the changed file: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)