### PR TITLE
chore(deps): resolve high-severity audit advisories (green audit gate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "lucide-react": "^1.8.0",
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^9.0.3",
         "pdf-lib": "^1.17.1",
         "perfect-debounce": "^2.1.0",
         "pino": "^10.3.1",
@@ -8547,9 +8547,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -8558,7 +8558,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -10788,9 +10789,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -11110,9 +11111,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -12862,9 +12863,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -13520,6 +13521,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lucide-react": "^1.8.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.3",
     "pdf-lib": "^1.17.1",
     "perfect-debounce": "^2.1.0",
     "pino": "^10.3.1",
@@ -72,5 +72,9 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs,json,css,md,yml,yaml}": "prettier --write"
+  },
+  "overrides": {
+    "tmp": "^0.2.7",
+    "fast-xml-builder": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Why

Restore a green **CI `dependency-audit`** gate (`npm audit --audit-level=high`). Three high-severity advisories remained after the better-auth upgrade (#173), all unrelated to better-auth.

## What changed (minimal, targeted — no breaking major bumps)

| Package | Change | Advisory | How it's pulled |
|---|---|---|---|
| `nodemailer` | `^8.0.5` → **`^9.0.3`** | CRLF header injection, improper TLS cert validation on OAuth2 token fetch, file/url-access bypass | direct dep (`src/lib/mail.ts`) |
| `tmp` | override → **`^0.2.7`** | path traversal | transitive via `exceljs` |
| `fast-xml-builder` | override → **`^1.3.0`** | attribute/regex bypass | transitive via `@aws-sdk` → `fast-xml-parser` (whose `^1.1.4` range already allows `1.3.0`, so no parser bump needed) |

I deliberately **did not** run `npm audit fix` — it proposed breaking **downgrades** of `next` (→9.3.3) and `exceljs` (→3.4.0). This is the surgical alternative.

`npm audit --audit-level=high` now exits **0** (zero high/critical). Remaining moderate/low advisories don't fail the gate.

## Verification (local, full deployment)

- `npm run build` ✓ (TypeScript clean), `eslint` ✓, `prettier` ✓.
- Booted the full local stack (MySQL + minio + mailpit + Next dev) with the seeded DB and an authenticated admin session. **Every page route renders 200 with real data.**
- **The three subsystems these deps actually touch, tested end-to-end:**
  - **Email** (nodemailer 9): password-reset mail delivered to mailpit ✓
  - **S3 upload/download** (fast-xml-builder 1.3.0 via aws-sdk): `uploadSignaturePng` + `downloadObject` round-trip matches ✓
  - **Exports** (tmp 0.2.7 / exceljs; also pdf-lib): **CSV, XLSX, and PDF** all produce valid output ✓
- 4 parallel feature-area sweeps (children/schools/holiday-plans/pools · school-assistants/user-management/2FA admin · exports/monthly-reports/handlungsbedarf · workshops/map/events/vertretung) — **all green**, no runtime errors. `tmp` and `fast-xml-builder` aren't imported anywhere in `src/` (purely transitive); `nodemailer`'s v8→v9 API is unchanged for our usage.

## Note

nodemailer is only used for **local-dev SMTP** — production sends via Resend — so the direct bump has no prod mail-path impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
