### PR TITLE
fix(2fa): recover from stale two_factor row blocking setup

### DIFF
--- a/src/app/2fa/setup/actions.ts
+++ b/src/app/2fa/setup/actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { requireAuth } from "@/lib/auth-guards";
+import { UserFacade } from "@/features/users";
+
+// Called by the setup form right before better-auth's twoFactor.enable(). If an
+// earlier enrollment was interrupted, a stale two_factor row lingers and enable()
+// would inherit its `verified` flag onto the new secret, making every code read
+// as invalid. Clearing it first keeps 2FA setup self-healing — no admin reset
+// needed. No-op once 2FA is actually enabled (see facade/service guard).
+export async function prepareTwoFactorSetupAction() {
+  const user = await requireAuth();
+  await UserFacade.clearUnverifiedTwoFactor(user.id);
+  return { success: true };
+}

--- a/src/app/2fa/setup/two-factor-setup.tsx
+++ b/src/app/2fa/setup/two-factor-setup.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import QRCode from "qrcode";
 
 import { authClient } from "@/lib/auth-client";
+import { prepareTwoFactorSetupAction } from "./actions";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -35,6 +36,17 @@ export function TwoFactorSetup() {
     e.preventDefault();
     setStatus("loading");
     setErrorMsg("");
+
+    // Clear any stale enrollment row from an interrupted setup before enabling,
+    // so better-auth generates a fresh, unverified secret instead of inheriting
+    // the old row's `verified` flag (which makes every code read as invalid).
+    try {
+      await prepareTwoFactorSetupAction();
+    } catch {
+      setErrorMsg("Die Einrichtung konnte nicht vorbereitet werden.");
+      setStatus("error");
+      return;
+    }
 
     const result = await authClient.twoFactor.enable({ password });
     if (result.error || !result.data) {

--- a/src/app/admin/user-management/page.tsx
+++ b/src/app/admin/user-management/page.tsx
@@ -32,6 +32,7 @@ export default async function UserManagementPage() {
         role: u.role,
         createdAt: u.createdAt.toISOString(),
         twoFactorEnabled: u.twoFactorEnabled,
+        hasTwoFactorRow: u.hasTwoFactorRow,
       }))}
       invitations={pendingInvitations}
       ownerCount={ownerCount}

--- a/src/features/users/components/admin-user-actions.tsx
+++ b/src/features/users/components/admin-user-actions.tsx
@@ -39,6 +39,7 @@ type Props = {
     email: string;
     role: Role;
     twoFactorEnabled: boolean;
+    hasTwoFactorRow: boolean;
   };
   currentUser: { id: string; role: Role };
   ownerCount: number;
@@ -57,9 +58,13 @@ export function AdminUserActions({ user, currentUser, ownerCount }: Props) {
   const showPromote =
     canPromoteToOwner(currentUser.role) && user.role === Role.ADMIN && !isSelf;
   const showRemove = canRemoveTarget(currentUser.role, user.role) && !isSelf;
+  // Show reset when 2FA is enabled OR a two_factor row merely exists: a stale
+  // row (e.g. an interrupted enrollment) can linger with twoFactorEnabled=false
+  // and blocks the user from setting up 2FA again ("Der Code ist ungültig"),
+  // so an admin must be able to clear it in that state too.
   const showResetTwoFactor =
     canResetTwoFactor(currentUser.role, user.role) &&
-    user.twoFactorEnabled &&
+    (user.twoFactorEnabled || user.hasTwoFactorRow) &&
     !isSelf;
   const showUnlockTwoFactor =
     canUnlockTwoFactor(currentUser.role, user.role) &&

--- a/src/features/users/components/user-management-table.tsx
+++ b/src/features/users/components/user-management-table.tsx
@@ -28,6 +28,7 @@ export type AdminUserRow = {
   role: Role;
   createdAt: string; // ISO
   twoFactorEnabled: boolean;
+  hasTwoFactorRow: boolean;
 };
 
 export type AdminInvitationRow = {

--- a/src/features/users/facade.ts
+++ b/src/features/users/facade.ts
@@ -9,6 +9,7 @@ import {
   countOwners,
   updateUserRole,
   resetUserTwoFactor,
+  clearUnverifiedTwoFactor,
   unlockUserTwoFactor,
 } from "./services";
 import { Role } from "@/generated/prisma";
@@ -69,6 +70,12 @@ export const UserFacade = {
 
   async resetTwoFactor(userId: string) {
     return resetUserTwoFactor(userId);
+  },
+
+  // Self-service cleanup before a fresh 2FA enrollment: removes a stale row left
+  // by an interrupted setup so better-auth's enable() starts from a clean slate.
+  async clearUnverifiedTwoFactor(userId: string) {
+    return clearUnverifiedTwoFactor(userId);
   },
 
   async unlockTwoFactor(userId: string) {

--- a/src/features/users/services/index.ts
+++ b/src/features/users/services/index.ts
@@ -26,7 +26,7 @@ export async function getAllSchoolAssistants() {
 }
 
 export async function listAdminUsers() {
-  return prisma.user.findMany({
+  const users = await prisma.user.findMany({
     where: { role: { in: [Role.ADMIN, Role.OWNER] } },
     orderBy: [{ role: "asc" }, { createdAt: "asc" }],
     select: {
@@ -36,8 +36,17 @@ export async function listAdminUsers() {
       role: true,
       createdAt: true,
       twoFactorEnabled: true,
+      // Surface whether a two_factor row exists at all — a stale/partially
+      // enrolled row can linger with twoFactorEnabled=false and block a fresh
+      // setup (better-auth's enable() inherits its `verified` flag), so admins
+      // need to be able to reset it even when 2FA reads as disabled.
+      _count: { select: { twoFactors: true } },
     },
   });
+  return users.map(({ _count, ...user }) => ({
+    ...user,
+    hasTwoFactorRow: _count.twoFactors > 0,
+  }));
 }
 
 export async function countOwners() {
@@ -64,6 +73,21 @@ export async function resetUserTwoFactor(id: string) {
     await tx.user.update({ where: { id }, data: { twoFactorEnabled: false } });
     return user;
   });
+}
+
+// Drops any leftover two_factor row for a user who has NOT completed 2FA setup
+// (twoFactorEnabled=false). An interrupted enrollment leaves a stale row behind;
+// better-auth's enable() then inherits that row's `verified` flag onto the fresh
+// secret, so every code the user enters reads as invalid. Clearing it first lets
+// a new setup start clean. Deliberately a no-op when 2FA is actually enabled, so
+// it can never wipe a working enrollment.
+export async function clearUnverifiedTwoFactor(id: string) {
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: { twoFactorEnabled: true },
+  });
+  if (!user || user.twoFactorEnabled) return;
+  await prisma.twoFactor.deleteMany({ where: { userId: id } });
 }
 
 // Lifts a temporary 2FA lockout (better-auth's accountLockout) without deleting


### PR DESCRIPTION
## Problem

`david.franke@tum.de` (and anyone with an interrupted 2FA enrollment) got **"Der Code ist ungültig"** on *every* code during 2FA setup.

**Root cause:** an interrupted enrollment leaves a stale `two_factor` row (`twoFactorEnabled=false`, secret present). The `20260719120000_two_factor_verified_and_lockout` migration added `verified BOOLEAN NOT NULL DEFAULT true`, so those stale rows were backfilled to `verified=true`. better-auth's `enable()` then copies that flag onto the freshly generated secret:

```js
verified: existingTwoFactor != null && existingTwoFactor.verified !== false || !!options?.skipVerificationOnEnable
```

`verifyTOTP` only flips `twoFactorEnabled → true` inside `if (twoFactor.verified !== true)`, which is now skipped — so enrollment can never complete. The setup UI maps *any* `verifyTotp` error to the generic "Der Code ist ungültig" (`two-factor-setup.tsx`), so it looks like a wrong code. (Server clock is NTP-synced; it wasn't skew.)

## Fix (two complementary layers)

1. **Setup self-heals.** `prepareTwoFactorSetupAction` clears any leftover `two_factor` row — *only when 2FA is disabled* — before `enable()` runs, so the new secret is created with `verified=false`. Users recover just by retrying; no admin action needed.
2. **Admin reset safety net.** The "2FA zurücksetzen" action now appears when a `two_factor` row merely exists (`hasTwoFactorRow`), not only when `twoFactorEnabled` is true, so a stuck user can be reset while 2FA still reads as disabled. `resetUserTwoFactor` already deletes the row + sets `twoFactorEnabled=false`.

## Changes
- `services/index.ts`: `clearUnverifiedTwoFactor(id)` (guarded no-op when 2FA enabled); `listAdminUsers` surfaces `hasTwoFactorRow` via `_count.twoFactors`
- `facade.ts`: exposes `clearUnverifiedTwoFactor`
- `src/app/2fa/setup/actions.ts`: new `prepareTwoFactorSetupAction` (`requireAuth` → facade)
- `two-factor-setup.tsx`: calls it before `enable()`
- `admin-user-actions.tsx` / `user-management-table.tsx` / `page.tsx`: OR condition + plumbing for `hasTwoFactorRow`

## Verification
- `npx tsc --noEmit` → 0 errors
- `npx eslint` (incl. `eslint-plugin-boundaries`) on all changed files → clean

## Notes
- No manual DB edit performed on production — david self-heals on retry after deploy.
- Follow-up worth considering: the migration's `verified DEFAULT true` is what flipped mid-enrollment rows; this PR makes it recoverable but doesn't change the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)