### PR TITLE
fix: make deploy-update reload banner clickable over an open detail Sheet

### DIFF
--- a/src/components/deployment-update-notice.tsx
+++ b/src/components/deployment-update-notice.tsx
@@ -87,7 +87,11 @@ export function DeploymentUpdateNotice() {
       aria-live="assertive"
       className="fixed inset-x-0 bottom-0 z-[100] flex justify-center p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)]"
     >
-      <div className="flex w-full max-w-2xl flex-col gap-3 rounded-lg border border-border/60 bg-background/95 p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+      {/* pointer-events-auto: a modal Radix dialog (e.g. an open detail Sheet)
+          sets pointer-events:none on <body>, which this banner inherits — it
+          would show above the dialog but the reload button wouldn't be
+          clickable. Re-enabling it on the card restores the click. */}
+      <div className="pointer-events-auto flex w-full max-w-2xl flex-col gap-3 rounded-lg border border-border/60 bg-background/95 p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-start gap-3">
           <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
             <RefreshCw className="size-4" />


### PR DESCRIPTION
## Problem

With a detail view open (e.g. a Schulbegleiter or child Sheet), the "Neue Version verfügbar" banner shows *above* the sheet but its **Neu laden** button isn't clickable — you have to close the sheet first.

## Cause

The detail views are shadcn **Sheets** (Radix `Dialog`, modal). A modal Radix dialog sets `pointer-events: none` on `<body>` while open (so clicks don't reach page content behind it). `pointer-events` is an **inherited** property, and the banner is a `<body>` descendant, so it inherits `none`. It still paints on top (`z-100` > the sheet's `z-50`), but nothing in it can be clicked.

## Fix

Add `pointer-events-auto` to the banner card. Per the CSS spec, a descendant can re-enable pointer events even when an ancestor has `pointer-events: none` — so the card and its button become clickable again, without affecting the sheet's modal behavior. Scoped to the card (not the full-width wrapper), so empty areas around it stay click-through. It's a no-op when no dialog is open (already `auto`).

## Verified
`tsc` clean, `prettier` clean. (`pointer-events-auto` is a core Tailwind utility; PR CI runs the full build.)

### How to confirm after deploy
Open a detail Sheet, trigger the banner (in the console: `fetch('/login',{method:'POST',headers:{'next-action':'x'}})`), and the **Neu laden** button should now be clickable without closing the sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)