### PR TITLE
fix(timesheet): reduce indirekte Leistung note minimum to 1 char

### DIFF
--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -232,7 +232,7 @@ export function NewEntrySheet({
     // INDIRECT
     return (
       indirectChildName.trim().length >= 2 &&
-      note.trim().length >= 3 &&
+      note.trim().length >= 1 &&
       Boolean(duration)
     );
   }, [

--- a/src/features/timesheet/schemas.ts
+++ b/src/features/timesheet/schemas.ts
@@ -76,11 +76,11 @@ export const CreateEventSchema = z
           path: ["childIds"],
           message: "Für eine indirekte Leistung genau ein Kind auswählen.",
         });
-      if (!val.note || val.note.trim().length < 3)
+      if (!val.note || val.note.trim().length < 1)
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["note"],
-          message: "Notiz ist Pflicht (mind. 3 Zeichen).",
+          message: "Notiz ist Pflicht (mind. 1 Zeichen).",
         });
       requireTimes();
     }
@@ -145,7 +145,11 @@ export const CreateIndirectByNameSchema = z
     date: dateStringSchema,
     startTime: timeStringSchema,
     endTime: timeStringSchema,
-    note: z.string().min(3, "Notiz ist Pflicht (mind. 3 Zeichen).").max(2000),
+    note: z
+      .string()
+      .trim()
+      .min(1, "Notiz ist Pflicht (mind. 1 Zeichen).")
+      .max(2000),
     signaturePngBase64: signatureSchema,
   })
   .refine((v) => v.endTime > v.startTime, {


### PR DESCRIPTION
## Problem

When a Schulbegleiter creates an *indirekte Leistung* entry, the note (Notiz) was required to be at least **3 characters**. In practice they often note work using acronyms that are as short as **1 character**, which the validation rejected.

## Change

Lower the minimum note length from 3 to **1** everywhere it was enforced for indirekte Leistung:

- `CreateIndirectByNameSchema` (the schema the SB entry sheet actually submits to) — now `.trim().min(1, …)`, so a lone whitespace no longer passes either.
- `CreateEventSchema` INDIRECT branch (legacy/other path) — `< 3` → `< 1`.
- Client-side submit gate in `new-entry-sheet.tsx` (`canProceed`) — `note.trim().length >= 3` → `>= 1`, so the button enables with a single character.

The note stays **required** for indirekte Leistung; only the minimum length is relaxed. Validation messages updated to "mind. 1 Zeichen".

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx prettier --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)