### PR TITLE
chore(auth): disable rate limiting outside production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ DATABASE_URL="mysql://root:lebenshilfe@localhost:3306/lebenshilfe_dev"
 BETTER_AUTH_SECRET="VERY_GOOD_LOCAL_SECRET"  # generate with: openssl rand -base64 32
 BETTER_AUTH_URL="http://localhost:3000"
 
+# Auth rate limiting. Defaults to on only in production (NODE_ENV=production), so
+# local scripts like `npm run db:seed` aren't throttled. Force it either way:
+# RATE_LIMIT_ENABLED=true to exercise the limits locally, =false to disable them.
+# RATE_LIMIT_ENABLED=true
+
 # Hetzner Object Storage (S3-compatible) — required for signature uploads
 # S3_ENDPOINT="https://fsn1.your-objectstorage.com"
 # S3_REGION="fsn1"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,6 +9,17 @@ import { ResetPasswordEmail } from "./email/templates/reset-password-email";
 import { logger } from "@/lib/logger";
 import { haveIBeenPwned, twoFactor } from "better-auth/plugins";
 
+// Rate limiting protects the auth endpoints (brute force / credential stuffing)
+// in production. Outside production it is off by default so local scripts that
+// fire many auth requests in a row aren't throttled — e.g. `npm run db:seed`,
+// which signs up every seed user in a loop through auth.handler. Set
+// RATE_LIMIT_ENABLED to override in either direction (RATE_LIMIT_ENABLED=true to
+// exercise the limits locally, =false to disable them anywhere).
+const rateLimitEnabled =
+  process.env.RATE_LIMIT_ENABLED !== undefined
+    ? process.env.RATE_LIMIT_ENABLED === "true"
+    : process.env.NODE_ENV === "production";
+
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: "mysql",
@@ -28,7 +39,7 @@ export const auth = betterAuth({
     }),
   ],
   rateLimit: {
-    enabled: true,
+    enabled: rateLimitEnabled,
     storage: "database",
     // Tightened per-IP limits on top of better-auth's defaults. Uses the
     // RateLimit table (prisma/schema.prisma) so counters survive restarts and


### PR DESCRIPTION
## Problem

Better Auth rate limiting was configured with `enabled: true` in **every** environment (`src/lib/auth.ts`). Because the DB-backed limiter also applies to in-process `auth.handler` calls, local scripts that fire many auth requests in a row get throttled — most notably `npm run db:seed`, which signs up each seed user through `auth.handler` in a loop.

## Change

- Gate `rateLimit.enabled` on `NODE_ENV === "production"`, mirroring the existing `useSecureCookies` convention already used a few lines below in the same file.
- Add a `RATE_LIMIT_ENABLED` env override so it can be forced on/off in any environment:
  - unset (default) → on only in production, off in local dev / seed scripts
  - `RATE_LIMIT_ENABLED=true` → exercise the limits locally
  - `RATE_LIMIT_ENABLED=false` → disable anywhere
- Document the variable in `.env.example`.

Production behaviour is unchanged: `NODE_ENV=production` is baked into the Dockerfile, so the limiter (and its tightened `customRules`) stays fully active in deployed environments. Only local dev — where `NODE_ENV` is `development` (`next dev`) or unset (`tsx scripts/seed.ts`) — runs unthrottled by default.

## Testing

- `npx eslint src/lib/auth.ts` — clean
- `npx prettier --check` — clean
- `npx tsc --noEmit` — no new errors (the one pre-existing `TwoFactor`/`failedVerificationCount` error is present on `main` and unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)