### PR TITLE
fix(timesheet): "Lehrkraft" statt "Vorgesetzter" im Monatsabschluss

### DIFF
--- a/src/features/timesheet/components/handover-dialog.tsx
+++ b/src/features/timesheet/components/handover-dialog.tsx
@@ -134,8 +134,8 @@ export function HandoverDialog({
             <div className="space-y-4">
               <div className="rounded-xl border border-border bg-muted/40 p-4">
                 <p className="text-sm">
-                  Bitte geben Sie Ihr Telefon nun an Ihre/n Vorgesetzte/n, damit
-                  diese/r den Monat prüfen und unterschreiben kann.
+                  Bitte geben Sie Ihr Telefon nun an Ihre Lehrkraft, damit diese
+                  den Monat prüfen und unterschreiben kann.
                 </p>
               </div>
 
@@ -155,7 +155,7 @@ export function HandoverDialog({
               </div>
 
               <div className="space-y-1.5">
-                <Label htmlFor="supervisor">Name Vorgesetzte/r</Label>
+                <Label htmlFor="supervisor">Name Lehrkraft</Label>
                 <Input
                   id="supervisor"
                   value={supervisorName}
@@ -282,7 +282,7 @@ export function HandoverDialog({
         onOpenChange={setSigOpen}
         title={`${MONTHS_LONG[month - 1]} ${year}`}
         subtitle={`${totals.count} Einträge · ${totals.hours} Arbeit · ${totals.sickDays} Krankentage`}
-        signerLabel={`${supervisorName || "Vorgesetzte/r"} (Vorgesetzte/r)`}
+        signerLabel={`${supervisorName || "Lehrkraft"} (Lehrkraft)`}
         onConfirm={submit}
         submitting={submitting}
       />

--- a/src/features/timesheet/components/tab-monat.tsx
+++ b/src/features/timesheet/components/tab-monat.tsx
@@ -132,10 +132,10 @@ export function TabMonat({
       >
         <ShieldCheck className="size-5" />
         {locked
-          ? "Bereits an Vorgesetzten übergeben"
+          ? "Bereits an Lehrkraft übergeben"
           : !monthCompleted
             ? "Monat noch nicht abgeschlossen"
-            : "An Vorgesetzten übergeben"}
+            : "An Lehrkraft übergeben"}
       </Button>
 
       <HandoverDialog

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -41,7 +41,7 @@ function assertMonthNotLocked(
 ) {
   if (report) {
     throw new Error(
-      "Der Monat wurde bereits an den Vorgesetzten übergeben und ist gesperrt.",
+      "Der Monat wurde bereits an die Lehrkraft übergeben und ist gesperrt.",
     );
   }
 }


### PR DESCRIPTION
## Was

Im Monatsabschluss/Freigabe-Flow der Schulbegleiter wird die unterschreibende Person überall als **"Lehrkraft"** statt **"Vorgesetzter"** bezeichnet.

## Geänderte Texte

- **Button** (`tab-monat.tsx`): „Bereits an Lehrkraft übergeben“ / „An Lehrkraft übergeben“
- **Hinweistext** (`handover-dialog.tsx`): „Bitte geben Sie Ihr Telefon nun an Ihre Lehrkraft, damit diese den Monat prüfen und unterschreiben kann.“
- **Feld-Label** (`handover-dialog.tsx`): „Name Lehrkraft“
- **Signatur-Label** (`handover-dialog.tsx`): „… (Lehrkraft)“
- **Fehlermeldung** (`facade.ts`): „Der Monat wurde bereits an die Lehrkraft übergeben und ist gesperrt.“

## Hinweise

- Grammatik an das feminine „die Lehrkraft“ angepasst; die genderneutralen Schrägstrich-Formen (`Ihre/n`, `Vorgesetzte/r`, `diese/r`) entfallen, da „Lehrkraft“ bereits geschlechtsneutral ist.
- **Nur Anzeigetexte** geändert. Interne Bezeichner und DB-Felder (`supervisorName`, `supervisorSignatureKey`, `id="supervisor"`) bleiben unverändert, um eine Migration zu vermeiden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)