### PR TITLE
feat(leistung): Leistungstyp in Historie & Monatsabschluss sichtbar machen

### DIFF
--- a/src/features/children/components/tabs/tab-history.tsx
+++ b/src/features/children/components/tabs/tab-history.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useReducer, useState, useTransition } from "react";
+import { useEffect, useMemo, useReducer, useState, useTransition } from "react";
 import {
   FileDown,
   Loader2,
@@ -193,6 +193,17 @@ export function TabHistory({ child, schoolAssistantOptions }: Props) {
   });
   const [isPending, startTransition] = useTransition();
   const [exportOpen, setExportOpen] = useState(false);
+
+  // A WORK entry is a Vertretung when this child has a Vertretung block for the
+  // same substitute (the entry's user) on the same day. Vertretung is not a flag
+  // on the Event, so it is derived from the child's serialized Vertretungen.
+  const vertretungKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const v of child.vertretungen) {
+      keys.add(`${v.substituteUserId}|${v.date}`);
+    }
+    return keys;
+  }, [child.vertretungen]);
 
   // null mid-switch (state still belongs to the previous child) → picker hidden.
   const active = state.childId === child.id ? state.period : null;
@@ -469,6 +480,16 @@ export function TabHistory({ child, schoolAssistantOptions }: Props) {
                         <span className="text-muted-foreground flex flex-col gap-0.5">
                           <span className="flex items-center gap-2">
                             {r.userName}
+                            {r.type === "INDIRECT" && (
+                              <span className="rounded bg-violet-500/10 px-1 py-0.5 text-[10px] text-violet-600">
+                                Indirekt
+                              </span>
+                            )}
+                            {vertretungKeys.has(`${r.userId}|${r.date}`) && (
+                              <span className="rounded bg-amber-500/15 px-1 py-0.5 text-[10px] text-amber-700">
+                                Vertretung
+                              </span>
+                            )}
                             {r.signed ? (
                               <>
                                 <span className="rounded bg-emerald-500/10 px-1 py-0.5 text-[10px] text-emerald-600">

--- a/src/features/timesheet/components/handover-dialog.tsx
+++ b/src/features/timesheet/components/handover-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Check, ShieldCheck } from "lucide-react";
 import {
   Dialog,
@@ -19,11 +19,11 @@ import { submitMonthlyReportAction } from "../actions";
 import {
   MONTHS_LONG,
   WEEKDAYS_SHORT,
-  formatDuration,
   timeToMinutes,
   weekdayIndex,
 } from "@/lib/dates";
 import type { Event } from "@/generated/prisma";
+import type { VertretungDay } from "./timesheet-shell";
 
 type Props = {
   open: boolean;
@@ -33,6 +33,8 @@ type Props = {
   events: Array<
     Pick<Event, "id" | "date" | "type" | "startTime" | "endTime" | "childId">
   >;
+  /** Days this user steps in as substitute — used to flag Vertretung entries. */
+  substituteOn?: VertretungDay[];
 };
 
 type Stage = "intro" | "sign" | "done";
@@ -43,6 +45,7 @@ export function HandoverDialog({
   year,
   month,
   events,
+  substituteOn = [],
 }: Props) {
   const [stage, setStage] = useState<Stage>("intro");
   const [supervisorName, setSupervisorName] = useState("");
@@ -62,23 +65,47 @@ export function HandoverDialog({
     return map;
   }, [events]);
 
+  // Vertretung is stored as a plain WORK Event; it is recognised by a matching
+  // Vertretung block (same child + day) among the days this user substitutes.
+  const vertretungKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const v of substituteOn) keys.add(`${v.childId}|${v.date}`);
+    return keys;
+  }, [substituteOn]);
+
+  const isVertretung = useCallback(
+    (ev: Pick<Event, "type" | "date" | "childId">) =>
+      ev.type === "WORK" &&
+      ev.childId != null &&
+      vertretungKeys.has(`${ev.childId}|${ev.date.toISOString().slice(0, 10)}`),
+    [vertretungKeys],
+  );
+
   const totals = useMemo(() => {
-    let workMinutes = 0;
+    let directMin = 0;
+    let indirectMin = 0;
+    let vertretungMin = 0;
     let sickDays = 0;
     for (const ev of events) {
-      if (ev.type === "SICK") sickDays++;
-      else if (ev.startTime && ev.endTime) {
-        workMinutes += timeToMinutes(ev.endTime) - timeToMinutes(ev.startTime);
+      if (ev.type === "SICK") {
+        sickDays++;
+        continue;
       }
+      if (!ev.startTime || !ev.endTime) continue;
+      const mins = timeToMinutes(ev.endTime) - timeToMinutes(ev.startTime);
+      if (ev.type === "INDIRECT") indirectMin += mins;
+      else if (isVertretung(ev)) vertretungMin += mins;
+      else directMin += mins;
     }
     return {
-      hours: `${Math.floor(workMinutes / 60)}h${
-        workMinutes % 60 ? ` ${workMinutes % 60}m` : ""
-      }`,
+      direct: fmtHm(directMin),
+      indirect: fmtHm(indirectMin),
+      vertretung: fmtHm(vertretungMin),
+      hours: fmtHm(directMin + indirectMin + vertretungMin),
       sickDays,
       count: events.length,
     };
-  }, [events]);
+  }, [events, isVertretung]);
 
   const reset = () => {
     setStage("intro");
@@ -139,18 +166,24 @@ export function HandoverDialog({
                 </p>
               </div>
 
-              <div className="grid grid-cols-3 gap-2 text-center">
+              <div className="grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
                 <Stat
-                  label="Stunden"
-                  value={totals.hours}
+                  label="Direkt"
+                  value={totals.direct}
+                />
+                <Stat
+                  label="Indirekt"
+                  value={totals.indirect}
+                />
+                <Stat
+                  label="Vertretung"
+                  value={totals.vertretung}
                 />
                 <Stat
                   label="Krank"
-                  value={String(totals.sickDays)}
-                />
-                <Stat
-                  label="Einträge"
-                  value={String(totals.count)}
+                  value={
+                    totals.sickDays === 1 ? "1 Tag" : `${totals.sickDays} Tage`
+                  }
                 />
               </div>
 
@@ -181,57 +214,40 @@ export function HandoverDialog({
                           e.startTime &&
                           e.endTime,
                       );
-                      const workMins = workEvents.reduce(
-                        (sum, e) =>
-                          sum +
-                          timeToMinutes(e.endTime!) -
-                          timeToMinutes(e.startTime!),
-                        0,
-                      );
-                      const earliestStart = workEvents.reduce<string | null>(
-                        (acc, e) =>
-                          !acc ||
-                          timeToMinutes(e.startTime!) < timeToMinutes(acc)
-                            ? e.startTime!
-                            : acc,
-                        null,
-                      );
-                      const latestEnd = workEvents.reduce<string | null>(
-                        (acc, e) =>
-                          !acc || timeToMinutes(e.endTime!) > timeToMinutes(acc)
-                            ? e.endTime!
-                            : acc,
-                        null,
-                      );
-                      const hoursLabel =
-                        workMins > 0
-                          ? formatDuration(
-                              "00:00",
-                              `${String(Math.floor(workMins / 60)).padStart(
-                                2,
-                                "0",
-                              )}:${String(workMins % 60).padStart(2, "0")}`,
-                            )
-                          : null;
                       return (
                         <li
                           key={day}
-                          className="flex items-center justify-between gap-2 px-3 py-2 text-sm"
+                          className="flex items-start justify-between gap-2 px-3 py-2 text-sm"
                         >
-                          <span className="font-mono tabular-nums text-muted-foreground">
+                          <span className="pt-0.5 font-mono tabular-nums text-muted-foreground">
                             {wd} {String(day).padStart(2, "0")}.
                           </span>
                           {sick ? (
                             <Badge className="bg-rose-500/15 text-rose-700 border-rose-200">
                               Krank
                             </Badge>
-                          ) : hoursLabel ? (
-                            <span className="flex items-baseline gap-2 font-mono tabular-nums">
-                              <span className="text-muted-foreground">
-                                {earliestStart}–{latestEnd}
-                              </span>
-                              <span>{hoursLabel}</span>
-                            </span>
+                          ) : workEvents.length > 0 ? (
+                            <div className="flex flex-col items-end gap-1">
+                              {workEvents.map((e) => (
+                                <span
+                                  key={e.id}
+                                  className="flex items-center gap-2 font-mono tabular-nums"
+                                >
+                                  <span className="text-muted-foreground">
+                                    {e.startTime}–{e.endTime}
+                                  </span>
+                                  {e.type === "INDIRECT" ? (
+                                    <Badge className="bg-violet-500/15 text-violet-700 border-violet-200">
+                                      Indirekt
+                                    </Badge>
+                                  ) : isVertretung(e) ? (
+                                    <Badge className="bg-amber-500/15 text-amber-700 border-amber-200">
+                                      Vertretung
+                                    </Badge>
+                                  ) : null}
+                                </span>
+                              ))}
+                            </div>
                           ) : (
                             <span className="text-muted-foreground">—</span>
                           )}
@@ -288,6 +304,10 @@ export function HandoverDialog({
       />
     </>
   );
+}
+
+function fmtHm(mins: number) {
+  return `${Math.floor(mins / 60)}h${mins % 60 ? ` ${mins % 60}m` : ""}`;
 }
 
 function Stat({ label, value }: { label: string; value: string }) {

--- a/src/features/timesheet/components/handover-dialog.tsx
+++ b/src/features/timesheet/components/handover-dialog.tsx
@@ -31,7 +31,12 @@ type Props = {
   year: number;
   month: number;
   events: Array<
-    Pick<Event, "id" | "date" | "type" | "startTime" | "endTime" | "childId">
+    Pick<
+      Event,
+      "id" | "date" | "type" | "startTime" | "endTime" | "childId"
+    > & {
+      child: { firstName: string; lastName: string } | null;
+    }
   >;
   /** Days this user steps in as substitute — used to flag Vertretung entries. */
   substituteOn?: VertretungDay[];
@@ -231,9 +236,14 @@ export function HandoverDialog({
                               {workEvents.map((e) => (
                                 <span
                                   key={e.id}
-                                  className="flex items-center gap-2 font-mono tabular-nums"
+                                  className="flex flex-wrap items-center justify-end gap-x-2 gap-y-0.5 text-right"
                                 >
-                                  <span className="text-muted-foreground">
+                                  {e.child && (
+                                    <span className="font-medium">
+                                      {e.child.firstName} {e.child.lastName}
+                                    </span>
+                                  )}
+                                  <span className="font-mono tabular-nums text-muted-foreground">
                                     {e.startTime}–{e.endTime}
                                   </span>
                                   {e.type === "INDIRECT" ? (

--- a/src/features/timesheet/components/tab-monat.tsx
+++ b/src/features/timesheet/components/tab-monat.tsx
@@ -17,7 +17,12 @@ type Props = {
   onViewDateChange: (d: Date) => void;
   onSelectDay: (d: Date) => void;
   events: Array<
-    Pick<Event, "id" | "date" | "type" | "startTime" | "endTime" | "childId">
+    Pick<
+      Event,
+      "id" | "date" | "type" | "startTime" | "endTime" | "childId"
+    > & {
+      child: { firstName: string; lastName: string } | null;
+    }
   >;
   lockedMonths: Set<string>;
   childSchoolHolidays?: ChildSchoolHolidayItem[];

--- a/src/features/timesheet/components/tab-monat.tsx
+++ b/src/features/timesheet/components/tab-monat.tsx
@@ -144,6 +144,7 @@ export function TabMonat({
         year={year}
         month={month}
         events={monthEvents}
+        substituteOn={monthSubstituteOn}
       />
     </div>
   );


### PR DESCRIPTION
## Was & Warum

Bisher war beim Ansehen einer Leistung nicht erkennbar, **welcher Typ** sie ist. Diese PR macht den Leistungstyp an zwei Stellen sichtbar — ohne DB-Migration (der Typ wird beim Rendern abgeleitet).

**Grundregel überall:** *direkte* Leistung ist der Standard und bekommt **keine** Zusatzkennzeichnung. Nur *indirekt* und *Vertretung* werden markiert.

### 1. Admin — Historie eines Kindes (`TabHistory`)
Jeder Eintrag zeigt jetzt farbige Pills neben dem Namen:
- **Indirekt** → violette Pill
- **Vertretung** → amber Pill (passend zur bestehenden Vertretungs-Farbe im Kalender)
- **Direkt** → keine Pill (Standard)

Vertretung ist kein Feld am `Event`, sondern wird aus den serialisierten `child.vertretungen` abgeleitet (Treffer bei gleichem `userId` + `date`).

### 2. Schulbegleiter — Monatsabschluss / Freigabe (`HandoverDialog`)
- Die Zusammenfassung schlüsselt die Arbeitszeit jetzt nach Typ auf: **Direkt · Indirekt · Vertretung · Krank** (statt nur *Stunden / Krank / Einträge*).
- Die Tagesliste zeigt **jeden einzelnen Eintrag** mit eigener Typ-Pill (statt einer aggregierten Tages-Zeitspanne), damit die Lehrkraft sieht, welche Einträge welcher Art tatsächlich gemacht wurden.
- Dafür wird `substituteOn` in den `HandoverDialog` durchgereicht, um Vertretungs-`WORK`-Events zu erkennen (Treffer bei gleichem `childId` + `date`).

## Umsetzungsdetails
- Keine Schema-/DB-Änderung. `Event.type` (`WORK`=direkt, `INDIRECT`=indirekt) war bereits vorhanden; Vertretung wird aus `ChildVertretung` (client-seitig bereits verfügbar) abgeleitet.
- Farben folgen den app-weiten Konventionen: rose=Krank, amber=Vertretung, violett=Indirekt.

## Betroffene Dateien
- `src/features/children/components/tabs/tab-history.tsx`
- `src/features/timesheet/components/handover-dialog.tsx`
- `src/features/timesheet/components/tab-monat.tsx`

## Checks
- `tsc --noEmit` ✅ · `eslint` ✅ · `prettier --check` ✅

## Hinweis für den Review
Rein visuelle Änderung — eine kurze Sichtprüfung im laufenden App (Historie eines Kindes mit indirekten/Vertretungs-Einträgen + Monatsabschluss-Dialog) wird empfohlen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)