### PR TITLE
fix(vertretung): repoint ChildVertretung from User to SchoolAssistantProfile

### DIFF
--- a/prisma/migrations/20260719150000_vertretung_to_profile/migration.sql
+++ b/prisma/migrations/20260719150000_vertretung_to_profile/migration.sql
@@ -1,0 +1,30 @@
+-- Repoint ChildVertretung (Vertretung) from the auth User to the
+-- SchoolAssistantProfile, mirroring the ChildAssignment change. A Vertretung is
+-- a per-date plan of WHO substitutes; modelling it on the profile (which exists
+-- from creation) lets an admin schedule a substitute before they accept their
+-- invitation, consistent with how Zuweisungen already work.
+
+-- Add the new FK column, nullable for the backfill window.
+ALTER TABLE `child_vertretung` ADD COLUMN `substituteProfileId` VARCHAR(191) NULL;
+
+-- Backfill: every existing Vertretung points at a registered assistant (whether
+-- created by an admin from the accepted-only dropdown or self-submitted by a
+-- logged-in Schulbegleiter), whose profile is uniquely linked via
+-- SchoolAssistantProfile.userId.
+UPDATE `child_vertretung` `cv`
+JOIN `school_assistant_profile` `p` ON `p`.`userId` = `cv`.`substituteUserId`
+SET `cv`.`substituteProfileId` = `p`.`id`;
+
+-- Safety net: drop any Vertretung that could not be matched to a profile
+-- (would otherwise block the NOT NULL + FK below). None are expected.
+DELETE FROM `child_vertretung` WHERE `substituteProfileId` IS NULL;
+
+-- Drop the old User FK, its index, and the column.
+ALTER TABLE `child_vertretung` DROP FOREIGN KEY `child_vertretung_substituteUserId_fkey`;
+DROP INDEX `child_vertretung_substituteUserId_date_idx` ON `child_vertretung`;
+ALTER TABLE `child_vertretung` DROP COLUMN `substituteUserId`;
+
+-- Finalise the new column: NOT NULL, indexed, FK to the profile.
+ALTER TABLE `child_vertretung` MODIFY `substituteProfileId` VARCHAR(191) NOT NULL;
+CREATE INDEX `child_vertretung_substituteProfileId_date_idx` ON `child_vertretung`(`substituteProfileId`, `date`);
+ALTER TABLE `child_vertretung` ADD CONSTRAINT `child_vertretung_substituteProfileId_fkey` FOREIGN KEY (`substituteProfileId`) REFERENCES `school_assistant_profile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,6 @@ model User {
   events                     Event[]
   monthlyReports             MonthlyReport[]
   profile                    SchoolAssistantProfile?
-  vertretungenAsSubstitute   ChildVertretung[]          @relation("SubstituteVertretung")
   createdChildAbsences       ChildAbsence[]             @relation("ChildAbsenceCreator")
   pendingVertretungRequests  PendingVertretungRequest[] @relation("PendingVertretungSubstitute")
   resolvedVertretungRequests PendingVertretungRequest[] @relation("PendingVertretungResolver")
@@ -261,20 +260,20 @@ model ChildAssignment {
 }
 
 model ChildVertretung {
-  id               String   @id @default(cuid())
-  childId          String
-  substituteUserId String
-  date             DateTime @db.Date
-  startTime        String
-  endTime          String
-  createdAt        DateTime @default(now())
-  child            Child    @relation(fields: [childId], references: [id], onDelete: Cascade)
-  substituteUser   User     @relation("SubstituteVertretung", fields: [substituteUserId], references: [id], onDelete: Cascade)
+  id                  String                 @id @default(cuid())
+  childId             String
+  substituteProfileId String
+  date                DateTime               @db.Date
+  startTime           String
+  endTime             String
+  createdAt           DateTime               @default(now())
+  child               Child                  @relation(fields: [childId], references: [id], onDelete: Cascade)
+  substituteProfile   SchoolAssistantProfile @relation(fields: [substituteProfileId], references: [id], onDelete: Cascade)
 
   /// Multiple rows per (childId, date) are intentional — one per time block,
   /// mirroring how ChildAssignment models multiple blocks per (childId, weekday).
   @@index([childId, date])
-  @@index([substituteUserId, date])
+  @@index([substituteProfileId, date])
   @@map("child_vertretung")
 }
 
@@ -401,6 +400,7 @@ model SchoolAssistantProfile {
   pool              Pool?                @relation(fields: [poolId], references: [id], onDelete: SetNull)
   attendances       WorkshopAttendance[]
   assignments       ChildAssignment[]
+  substituteVertretungen ChildVertretung[]
 
   @@index([status])
   @@index([poolId])

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -689,10 +689,21 @@ async function assignChildren() {
   }
 }
 
-async function seedVertretungen(usersByEmail: Record<string, string>) {
+async function seedVertretungen() {
   console.log("Seeding Vertretungen (substitute coverage)…");
-  const annaId = usersByEmail["anna.schmidt@lebenshilfe.de"];
-  const claraId = usersByEmail["clara.becker@lebenshilfe.de"];
+  // ChildVertretung is keyed by SchoolAssistantProfile, so resolve profile ids
+  // (mirroring assignChildren) rather than User ids.
+  const profiles = await prisma.schoolAssistantProfile.findMany({
+    where: {
+      email: {
+        in: ["anna.schmidt@lebenshilfe.de", "clara.becker@lebenshilfe.de"],
+      },
+    },
+    select: { id: true, email: true },
+  });
+  const byEmail = Object.fromEntries(profiles.map((p) => [p.email, p.id]));
+  const annaId = byEmail["anna.schmidt@lebenshilfe.de"];
+  const claraId = byEmail["clara.becker@lebenshilfe.de"];
 
   // Illustrative substitute coverage so the Vertretung UI (homepage cards,
   // week calendar, admin views) has data to render. Each record copies the
@@ -701,19 +712,19 @@ async function seedVertretungen(usersByEmail: Record<string, string>) {
   // Vertretung lands in the future.
   const vertretungen: Array<{
     childId: string;
-    substituteUserId: string;
+    substituteProfileId: string;
     date: Date;
   }> = [
     // Anna steps in for Paul (normally Clara's) — populates Anna's homepage.
     {
       childId: "seed-paul-koch",
-      substituteUserId: annaId,
+      substituteProfileId: annaId,
       date: nthWeekdayBefore(4),
     },
     // Clara steps in for Max (normally Anna's).
     {
       childId: "seed-max-huber",
-      substituteUserId: claraId,
+      substituteProfileId: claraId,
       date: nthWeekdayBefore(6),
     },
   ];
@@ -730,7 +741,7 @@ async function seedVertretungen(usersByEmail: Record<string, string>) {
     await prisma.childVertretung.createMany({
       data: timeBlocks.map((b) => ({
         childId: v.childId,
-        substituteUserId: v.substituteUserId,
+        substituteProfileId: v.substituteProfileId,
         date: v.date,
         startTime: b.startTime,
         endTime: b.endTime,
@@ -1030,7 +1041,7 @@ async function main() {
   await seedSchools();
   await seedChildrenAndSchedules();
   await assignChildren();
-  await seedVertretungen(usersByEmail);
+  await seedVertretungen();
   await seedChildAbsences();
   await enrichProfiles();
   await seedEvents(usersByEmail);

--- a/src/app/admin/handlungsbedarf/page.tsx
+++ b/src/app/admin/handlungsbedarf/page.tsx
@@ -61,9 +61,12 @@ export default async function HandlungsbedarfPage() {
     lastName: c.lastName,
   }));
 
-  const schoolAssistantOptions = schoolAssistants
-    .filter((p) => !!p.userId)
-    .map((p) => ({ id: p.userId as string, name: p.name }));
+  // Vertretung is keyed by SchoolAssistantProfile, so the substitute picker
+  // offers profile ids (every assistant, incl. not-yet-accepted ones).
+  const schoolAssistantOptions = schoolAssistants.map((p) => ({
+    id: p.id,
+    name: p.name,
+  }));
 
   // Narrow the facade's ProblemFlag[] back to each list's expected subset.
   // The facade promises only krankheit kinds in listKrankheitFlags and only

--- a/src/features/children/components/calendar/day-quick-add.tsx
+++ b/src/features/children/components/calendar/day-quick-add.tsx
@@ -133,7 +133,7 @@ export function DayQuickAddSection({
         <VertretungChip
           childId={childId}
           date={formatIsoDateLocal(date)}
-          substituteUserId={vertretungen[0].substituteUserId}
+          substituteProfileId={vertretungen[0].substituteProfileId}
           substituteUserName={vertretungen[0].substituteUserName}
           timeBlocks={vertretungen.map((v) => ({
             startTime: v.startTime,
@@ -300,7 +300,7 @@ function DayChip({
 function VertretungChip({
   childId,
   date,
-  substituteUserId: initialSubstituteUserId,
+  substituteProfileId: initialSubstituteProfileId,
   substituteUserName,
   timeBlocks,
   schoolAssistantOptions,
@@ -309,7 +309,7 @@ function VertretungChip({
 }: {
   childId: string;
   date: string;
-  substituteUserId: string;
+  substituteProfileId: string;
   substituteUserName: string;
   timeBlocks: { startTime: string; endTime: string }[];
   schoolAssistantOptions: SchoolAssistantOption[];
@@ -317,24 +317,24 @@ function VertretungChip({
   onChanged: () => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [substituteUserId, setSubstituteUserId] = useState(
-    initialSubstituteUserId,
+  const [substituteProfileId, setSubstituteProfileId] = useState(
+    initialSubstituteProfileId,
   );
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
-      setSubstituteUserId(initialSubstituteUserId);
+      setSubstituteProfileId(initialSubstituteProfileId);
       setError(null);
     }
-  }, [open, initialSubstituteUserId]);
+  }, [open, initialSubstituteProfileId]);
 
   async function handleSave() {
     setBusy(true);
     setError(null);
     try {
-      await updateVertretungAction(childId, date, { substituteUserId });
+      await updateVertretungAction(childId, date, { substituteProfileId });
       toast.success("Vertretung aktualisiert.");
       setOpen(false);
       onChanged();
@@ -395,8 +395,8 @@ function VertretungChip({
             <Label className="text-xs text-muted-foreground">Vertreter</Label>
             <SchoolAssistantCombobox
               options={schoolAssistantOptions}
-              value={substituteUserId}
-              onChange={(id) => setSubstituteUserId(id ?? "")}
+              value={substituteProfileId}
+              onChange={(id) => setSubstituteProfileId(id ?? "")}
               placeholder="Wer vertritt?"
             />
           </div>
@@ -547,14 +547,14 @@ function DayVertretungForm({
           .join(", ")
       : "00:00–23:59";
 
-  const [substituteUserId, setSubstituteUserId] = useState(
+  const [substituteProfileId, setSubstituteProfileId] = useState(
     schoolAssistantOptions[0]?.id ?? "",
   );
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function handleSave() {
-    if (!substituteUserId) {
+    if (!substituteProfileId) {
       setError("Bitte den Vertreter wählen.");
       return;
     }
@@ -563,7 +563,7 @@ function DayVertretungForm({
     try {
       await createVertretungAction({
         childId,
-        substituteUserId,
+        substituteProfileId,
         date: formatIsoDateLocal(date),
       });
       toast.success("Vertretung gespeichert.");
@@ -585,8 +585,8 @@ function DayVertretungForm({
         <Label className="text-xs text-muted-foreground">Vertreter</Label>
         <SchoolAssistantCombobox
           options={schoolAssistantOptions}
-          value={substituteUserId || null}
-          onChange={(id) => setSubstituteUserId(id ?? "")}
+          value={substituteProfileId || null}
+          onChange={(id) => setSubstituteProfileId(id ?? "")}
           placeholder="Wer vertritt?"
         />
       </div>

--- a/src/features/children/components/tabs/tab-history.tsx
+++ b/src/features/children/components/tabs/tab-history.tsx
@@ -200,6 +200,9 @@ export function TabHistory({ child, schoolAssistantOptions }: Props) {
   const vertretungKeys = useMemo(() => {
     const keys = new Set<string>();
     for (const v of child.vertretungen) {
+      // Skip invitation-pending substitutes (no linked User) — they cannot have
+      // signed WORK Events to correlate with.
+      if (!v.substituteUserId) continue;
       keys.add(`${v.substituteUserId}|${v.date}`);
     }
     return keys;

--- a/src/features/children/facade.ts
+++ b/src/features/children/facade.ts
@@ -278,7 +278,7 @@ export const ChildrenFacade = {
 
     await createVertretungBlocks({
       childId: parsed.childId,
-      substituteUserId: parsed.substituteUserId,
+      substituteProfileId: parsed.substituteProfileId,
       date,
       timeBlocks,
     });
@@ -293,7 +293,7 @@ export const ChildrenFacade = {
     await updateVertretungSubstituteForDate(
       childId,
       new Date(`${date}T00:00:00.000Z`),
-      parsed.substituteUserId,
+      parsed.substituteProfileId,
     );
   },
 

--- a/src/features/children/schemas.ts
+++ b/src/features/children/schemas.ts
@@ -145,7 +145,7 @@ export type AbsenceInput = z.infer<typeof AbsenceSchema>;
 
 export const VertretungSchema = z.object({
   childId: z.string().min(1),
-  substituteUserId: z.string().min(1),
+  substituteProfileId: z.string().min(1),
   date: dateString,
   // startTime / endTime are NOT provided by the caller — they are copied
   // directly from the ChildAssignment rows for that child+weekday.
@@ -154,7 +154,7 @@ export type VertretungInput = z.infer<typeof VertretungSchema>;
 
 export const UpdateVertretungSchema = z.object({
   // Only the substitute can be changed; times always mirror the Zuweisung.
-  substituteUserId: z.string().min(1),
+  substituteProfileId: z.string().min(1),
 });
 export type UpdateVertretungInput = z.infer<typeof UpdateVertretungSchema>;
 

--- a/src/features/children/serialize.ts
+++ b/src/features/children/serialize.ts
@@ -27,6 +27,10 @@ export type SerializedAbsence = {
 export type SerializedVertretung = {
   id: string;
   substituteProfileId: string;
+  // Linked account of the substitute, null while the profile is still
+  // invitation-pending. Used to correlate signed WORK Events (keyed by User)
+  // with the Vertretung; the picker uses substituteProfileId instead.
+  substituteUserId: string | null;
   substituteUserName: string;
   date: string; // YYYY-MM-DD
   startTime: string;
@@ -154,6 +158,7 @@ export function serializeChild(c: ChildWithRelations): SerializedChild {
     vertretungen: c.vertretungen.map((v) => ({
       id: v.id,
       substituteProfileId: v.substituteProfileId,
+      substituteUserId: v.substituteProfile.userId,
       substituteUserName: v.substituteProfile.name,
       date: formatIsoDateUtc(v.date),
       startTime: v.startTime,

--- a/src/features/children/serialize.ts
+++ b/src/features/children/serialize.ts
@@ -26,7 +26,7 @@ export type SerializedAbsence = {
 
 export type SerializedVertretung = {
   id: string;
-  substituteUserId: string;
+  substituteProfileId: string;
   substituteUserName: string;
   date: string; // YYYY-MM-DD
   startTime: string;
@@ -153,8 +153,8 @@ export function serializeChild(c: ChildWithRelations): SerializedChild {
     })),
     vertretungen: c.vertretungen.map((v) => ({
       id: v.id,
-      substituteUserId: v.substituteUserId,
-      substituteUserName: v.substituteUser.name,
+      substituteProfileId: v.substituteProfileId,
+      substituteUserName: v.substituteProfile.name,
       date: formatIsoDateUtc(v.date),
       startTime: v.startTime,
       endTime: v.endTime,

--- a/src/features/children/services/children.ts
+++ b/src/features/children/services/children.ts
@@ -9,7 +9,7 @@ export type ChildWithRelations = Prisma.ChildGetPayload<{
     assignments: { include: { profile: true } };
     schedules: true;
     absences: true;
-    vertretungen: { include: { substituteUser: true } };
+    vertretungen: { include: { substituteProfile: true } };
   };
 }>;
 
@@ -24,7 +24,7 @@ const childInclude = {
   assignments: { include: { profile: true } },
   schedules: true,
   absences: true,
-  vertretungen: { include: { substituteUser: true } },
+  vertretungen: { include: { substituteProfile: true } },
 } satisfies Prisma.ChildInclude;
 
 export async function listChildren(): Promise<ChildWithRelations[]> {

--- a/src/features/children/services/vertretung.ts
+++ b/src/features/children/services/vertretung.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/prisma";
 export async function listVertretungenForChild(childId: string) {
   return prisma.childVertretung.findMany({
     where: { childId },
-    include: { substituteUser: true },
+    include: { substituteProfile: true },
     orderBy: { date: "asc" },
   });
 }
@@ -14,7 +14,7 @@ export async function listVertretungenForUserAsSubstitute(
   to: Date,
 ) {
   return prisma.childVertretung.findMany({
-    where: { substituteUserId: userId, date: { gte: from, lt: to } },
+    where: { substituteProfile: { userId }, date: { gte: from, lt: to } },
     include: { child: true },
     orderBy: { date: "asc" },
   });
@@ -22,14 +22,14 @@ export async function listVertretungenForUserAsSubstitute(
 
 export async function createVertretungBlocks(data: {
   childId: string;
-  substituteUserId: string;
+  substituteProfileId: string;
   date: Date;
   timeBlocks: { startTime: string; endTime: string }[];
 }) {
   await prisma.childVertretung.createMany({
     data: data.timeBlocks.map((block) => ({
       childId: data.childId,
-      substituteUserId: data.substituteUserId,
+      substituteProfileId: data.substituteProfileId,
       date: data.date,
       startTime: block.startTime,
       endTime: block.endTime,
@@ -40,11 +40,11 @@ export async function createVertretungBlocks(data: {
 export async function updateVertretungSubstituteForDate(
   childId: string,
   date: Date,
-  substituteUserId: string,
+  substituteProfileId: string,
 ) {
   await prisma.childVertretung.updateMany({
     where: { childId, date },
-    data: { substituteUserId },
+    data: { substituteProfileId },
   });
 }
 
@@ -69,10 +69,10 @@ export async function syncVertretungBlocksForChildWeekday(
 
   const allRows = await prisma.childVertretung.findMany({
     where: { childId },
-    select: { date: true, substituteUserId: true },
+    select: { date: true, substituteProfileId: true },
   });
 
-  const byDate = new Map<string, { date: Date; substituteUserId: string }>();
+  const byDate = new Map<string, { date: Date; substituteProfileId: string }>();
   for (const row of allRows) {
     const wd = (row.date.getUTCDay() + 6) % 7;
     if (wd !== weekday) continue;
@@ -80,7 +80,7 @@ export async function syncVertretungBlocksForChildWeekday(
     if (!byDate.has(key)) {
       byDate.set(key, {
         date: row.date,
-        substituteUserId: row.substituteUserId,
+        substituteProfileId: row.substituteProfileId,
       });
     }
   }
@@ -98,7 +98,7 @@ export async function syncVertretungBlocksForChildWeekday(
     data: entries.flatMap((entry) =>
       schedules.map((s) => ({
         childId,
-        substituteUserId: entry.substituteUserId,
+        substituteProfileId: entry.substituteProfileId,
         date: entry.date,
         startTime: s.startTime,
         endTime: s.endTime,
@@ -108,13 +108,13 @@ export async function syncVertretungBlocksForChildWeekday(
 }
 
 export async function getVertretungCoverage(
-  substituteUserId: string,
+  userId: string,
   childIds: string[],
   date: Date,
 ): Promise<Set<string>> {
   if (childIds.length === 0) return new Set();
   const rows = await prisma.childVertretung.findMany({
-    where: { substituteUserId, childId: { in: childIds }, date },
+    where: { substituteProfile: { userId }, childId: { in: childIds }, date },
     select: { childId: true },
   });
   return new Set(rows.map((r) => r.childId));

--- a/src/features/handlungsbedarf/components/sick-flags-list.tsx
+++ b/src/features/handlungsbedarf/components/sick-flags-list.tsx
@@ -242,17 +242,19 @@ function VertretungQuickAction({
   schoolAssistantOptions: SchoolAssistantOption[];
 }) {
   const [open, setOpen] = useState(false);
-  const [substituteUserId, setSubstituteUserId] = useState<string | null>(null);
+  const [substituteProfileId, setSubstituteProfileId] = useState<string | null>(
+    null,
+  );
   const [pending, startTransition] = useTransition();
 
   const handleSave = () => {
-    if (!substituteUserId) return;
+    if (!substituteProfileId) return;
     startTransition(async () => {
       try {
-        await createVertretungAction({ childId, substituteUserId, date });
+        await createVertretungAction({ childId, substituteProfileId, date });
         toast.success("Vertretung eingetragen.");
         setOpen(false);
-        setSubstituteUserId(null);
+        setSubstituteProfileId(null);
       } catch (err) {
         toast.error(
           err instanceof Error ? err.message : "Speichern fehlgeschlagen.",
@@ -266,7 +268,7 @@ function VertretungQuickAction({
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
-        if (!next) setSubstituteUserId(null);
+        if (!next) setSubstituteProfileId(null);
       }}
     >
       <PopoverTrigger asChild>
@@ -287,8 +289,8 @@ function VertretungQuickAction({
             <Label className="text-xs text-muted-foreground">Vertreter</Label>
             <SchoolAssistantCombobox
               options={schoolAssistantOptions}
-              value={substituteUserId}
-              onChange={setSubstituteUserId}
+              value={substituteProfileId}
+              onChange={setSubstituteProfileId}
               placeholder="Wer vertritt?"
             />
           </div>
@@ -300,7 +302,7 @@ function VertretungQuickAction({
               type="button"
               size="sm"
               onClick={handleSave}
-              disabled={!substituteUserId || pending}
+              disabled={!substituteProfileId || pending}
             >
               {pending ? "Speichert…" : "Anlegen"}
             </Button>

--- a/src/features/handlungsbedarf/services/index.ts
+++ b/src/features/handlungsbedarf/services/index.ts
@@ -34,16 +34,23 @@ export async function findAssignmentsByUserIds(userIds: string[]) {
 }
 
 export async function findVertretungenInRange(from: Date, to: Date) {
-  return prisma.childVertretung.findMany({
+  const rows = await prisma.childVertretung.findMany({
     where: { date: { gte: from, lte: to } },
     select: {
       childId: true,
       date: true,
-      substituteUserId: true,
       child: { select: { firstName: true, lastName: true } },
-      substituteUser: { select: { name: true } },
+      substituteProfile: { select: { userId: true, name: true } },
     },
   });
+  // Reach the substitute's account through the profile relation. A pending
+  // profile has no linked User (userId null); it can never be "also sick" (no
+  // User → no sick Event), so the empty id simply never matches a sick key.
+  return rows.map(({ substituteProfile, ...rest }) => ({
+    ...rest,
+    substituteUserId: substituteProfile.userId ?? "",
+    substituteUser: { name: substituteProfile.name },
+  }));
 }
 
 export async function findChildAbsencesInRange(from: Date, to: Date) {

--- a/src/features/vertretung-requests/services/index.ts
+++ b/src/features/vertretung-requests/services/index.ts
@@ -137,11 +137,13 @@ export async function findExistingVertretungForSubstitute(args: {
   date: Date;
   substituteUserId: string;
 }) {
+  // ChildVertretung is keyed by SchoolAssistantProfile; the caller passes the
+  // logged-in Schulbegleiter's User id, which we reach via the profile relation.
   return prisma.childVertretung.findFirst({
     where: {
       childId: args.childId,
       date: args.date,
-      substituteUserId: args.substituteUserId,
+      substituteProfile: { userId: args.substituteUserId },
     },
     select: { id: true },
   });
@@ -160,15 +162,23 @@ export async function insertChildVertretungBlocks(args: {
   date: Date;
   blocks: { startTime: string; endTime: string }[];
 }) {
-  return prisma.childVertretung.createMany({
-    data: args.blocks.map((b) => ({
-      childId: args.childId,
-      substituteUserId: args.substituteUserId,
-      date: args.date,
-      startTime: b.startTime,
-      endTime: b.endTime,
-    })),
-  });
+  // ChildVertretung is keyed by SchoolAssistantProfile. The submitter is a
+  // logged-in Schulbegleiter (a real User), so connect to their profile via the
+  // unique userId. createMany cannot use a relation connect, so create the
+  // blocks individually within one transaction.
+  return prisma.$transaction(
+    args.blocks.map((b) =>
+      prisma.childVertretung.create({
+        data: {
+          child: { connect: { id: args.childId } },
+          substituteProfile: { connect: { userId: args.substituteUserId } },
+          date: args.date,
+          startTime: b.startTime,
+          endTime: b.endTime,
+        },
+      }),
+    ),
+  );
 }
 
 export async function deleteChildVertretungForSubstitute(args: {
@@ -179,7 +189,7 @@ export async function deleteChildVertretungForSubstitute(args: {
   return prisma.childVertretung.deleteMany({
     where: {
       childId: args.childId,
-      substituteUserId: args.substituteUserId,
+      substituteProfile: { userId: args.substituteUserId },
       date: args.date,
     },
   });


### PR DESCRIPTION
## Problem
Admins got *"An error occurred in the Server Components render"* when assigning a **Vertretung** on `/admin/children`. Root cause: `PrismaClientKnownRequestError` **P2003** — the substitute picker emits `SchoolAssistantProfile` ids, but `ChildVertretung.substituteUserId` is a hard FK to `User`.

Introduced by #139, which repointed **Zuweisungen** to profiles and switched the shared substitute dropdown to profile ids, but left **Vertretungen** on the `User` FK — so every admin "Vertretung eintragen" pushed a profile id into a `User` FK and crashed.

## Fix
A Vertretung is a per-date plan of *who* substitutes — structurally the same as a Zuweisung — not proof of completed work (the signed **Eintrag**/`Event` is a separate record). So model it the same way: repoint `ChildVertretung` from `User` to `SchoolAssistantProfile`, mirroring #139. This also lets admins schedule substitutions for **not-yet-registered** Schulbegleiter, symmetric with assignments.

- `schema.prisma`: `substituteUserId` → `substituteProfileId` (FK → `SchoolAssistantProfile`), relation/back-relations/index moved off `User`
- Migration `20260719150000_vertretung_to_profile`: safe backfill via `profile.userId` (add nullable → backfill → drop orphans → NOT NULL + FK), same pattern as the assignment migration
- Admin write paths use `substituteProfileId`; substitute pickers on `/admin/children` **and** `/admin/handlungsbedarf` now offer profile ids for every assistant
- User-keyed paths (SB self-service in `vertretung-requests`, coverage, SB dashboard, "substitute also sick") reach the account via the `substituteProfile: { userId }` relation
- `PendingVertretungRequest.substituteUserId` is a **separate** `User` FK — unchanged
- Seed updated

## Verification
- **Prod data**: 7 `child_vertretung` rows, **0 orphans** → migration is non-lossy
- `prisma migrate diff` confirms the migration's end-state matches the schema
- `tsc --noEmit` clean; `eslint` (incl. `boundaries`) clean

## Note
Substitute pickers now list every assistant incl. invitation-pending ones. A pending SB scheduled as a substitute activates once they accept (same as assignments) — they can't produce the actual Eintrag until they have a login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)