### PR TITLE
feat(timesheet): show unassigned free-text entries with a notice

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ export default async function LandingPage() {
     vertretungenAsSubstitute,
     allChildren,
     pendingVertretungRequests,
+    pendingIndirectRequests,
   ] = await Promise.all([
     TimesheetFacade.getEventsInRange(user.id, rangeStart, rangeEnd),
     TimesheetFacade.getSchedulesForChildren(childIds),
@@ -63,6 +64,7 @@ export default async function LandingPage() {
     ),
     ChildrenFacade.list(),
     VertretungRequestsFacade.listForUser(user.id, rangeStart, rangeEnd),
+    VertretungRequestsFacade.listIndirectForUser(user.id, rangeStart, rangeEnd),
   ]);
 
   // Resolve each assigned child's school holiday-plan ranges so the day view can
@@ -132,6 +134,14 @@ export default async function LandingPage() {
         startTime: r.startTime,
         endTime: r.endTime,
         status: r.status as "PENDING" | "RESOLVED",
+      }))}
+      pendingIndirectRequests={pendingIndirectRequests.map((r) => ({
+        id: r.id,
+        date: r.date.toISOString().slice(0, 10),
+        childNameText: r.childNameText,
+        startTime: r.startTime,
+        endTime: r.endTime,
+        note: r.note,
       }))}
     />
   );

--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -8,6 +8,7 @@ import {
   Palmtree,
   Plus,
   Stethoscope,
+  TriangleAlert,
   UserCheck,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -34,6 +35,7 @@ import type { ChildOption } from "./children-filter";
 import type {
   ChildAbsenceItem,
   ChildSchoolHolidayItem,
+  PendingIndirectRequestItem,
   PendingVertretungRequestItem,
   VertretungDay,
 } from "./timesheet-shell";
@@ -60,9 +62,28 @@ type Props = {
   assignmentsByWeekday: AssignmentsByWeekday;
   substituteOn?: VertretungDay[];
   pendingVertretungRequests?: PendingVertretungRequestItem[];
+  pendingIndirectRequests?: PendingIndirectRequestItem[];
 };
 
 const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// Shown on free-text entries whose name has not yet been matched to a child.
+function UnassignedNotice() {
+  return (
+    <div className="mt-3 flex gap-2 rounded-md border border-amber-300 bg-amber-100/60 p-2.5 text-xs text-amber-900">
+      <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+      <div>
+        <p className="font-medium">Noch keinem Kind zugeordnet</p>
+        <p className="mt-0.5">
+          Der eingegebene Name konnte keinem Kind zugeordnet werden. Bitte
+          erstellen Sie den Eintrag mit dem korrekten Namen neu oder warten Sie,
+          bis ein Admin ihn zuordnet. Bis dahin wird er nicht im Monatsabschluss
+          berücksichtigt.
+        </p>
+      </div>
+    </div>
+  );
+}
 
 export function TabDay({
   currentUserId,
@@ -79,6 +100,7 @@ export function TabDay({
   assignmentsByWeekday,
   substituteOn = [],
   pendingVertretungRequests = [],
+  pendingIndirectRequests = [],
 }: Props) {
   const [busyId, setBusyId] = useState<string | null>(null);
 
@@ -216,6 +238,11 @@ export function TabDay({
   const dayPendingRequests = useMemo(
     () => pendingVertretungRequests.filter((r) => r.date === selectedDateIso),
     [pendingVertretungRequests, selectedDateIso],
+  );
+
+  const dayPendingIndirectRequests = useMemo(
+    () => pendingIndirectRequests.filter((r) => r.date === selectedDateIso),
+    [pendingIndirectRequests, selectedDateIso],
   );
 
   const handleDeleteRequest = async (id: string) => {
@@ -571,8 +598,42 @@ export function TabDay({
                 Löschen
               </Button>
             </div>
+            <UnassignedNotice />
           </Card>
         ))}
+
+      {dayPendingIndirectRequests.map((req) => (
+        <Card
+          key={req.id}
+          className="border-amber-200 bg-amber-500/5 p-4"
+        >
+          <div className="flex items-start gap-3">
+            <div className="grid place-items-center size-10 shrink-0 rounded-full bg-amber-500/15 text-amber-700">
+              <Clock className="size-5" />
+            </div>
+            <div className="flex-1 space-y-0.5">
+              <p className="font-semibold text-amber-900">Indirekte Leistung</p>
+              <p className="text-sm text-amber-900/80">{req.childNameText}</p>
+              <p className="font-mono text-xs text-amber-700">
+                {req.startTime}–{req.endTime}
+              </p>
+              {req.note && (
+                <p className="text-sm text-amber-900/70">{req.note}</p>
+              )}
+            </div>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => handleDeleteRequest(req.id)}
+              disabled={busyId === req.id}
+              className="text-muted-foreground"
+            >
+              Löschen
+            </Button>
+          </div>
+          <UnassignedNotice />
+        </Card>
+      ))}
 
       {sickEvent && (
         <Card className="border-rose-200 bg-rose-500/10 p-4">
@@ -715,16 +776,19 @@ export function TabDay({
         </div>
       )}
 
-      {dayEvents.length === 0 && (
-        <Card className="flex flex-col items-center gap-3 border-dashed py-10 text-center">
-          <p className="text-sm text-muted-foreground">Keine Einträge</p>
-          {!locked && (
-            <Button onClick={onRequestNewEntry}>
-              <Plus className="size-4" /> Eintrag hinzufügen
-            </Button>
-          )}
-        </Card>
-      )}
+      {dayEvents.length === 0 &&
+        dayVertretungenGrouped.length === 0 &&
+        !dayPendingRequests.some((r) => r.status === "PENDING") &&
+        dayPendingIndirectRequests.length === 0 && (
+          <Card className="flex flex-col items-center gap-3 border-dashed py-10 text-center">
+            <p className="text-sm text-muted-foreground">Keine Einträge</p>
+            {!locked && (
+              <Button onClick={onRequestNewEntry}>
+                <Plus className="size-4" /> Eintrag hinzufügen
+              </Button>
+            )}
+          </Card>
+        )}
 
       {!locked && (
         <Button

--- a/src/features/timesheet/components/timesheet-shell.tsx
+++ b/src/features/timesheet/components/timesheet-shell.tsx
@@ -85,6 +85,17 @@ export type PendingVertretungRequestItem = {
   status: "PENDING" | "RESOLVED";
 };
 
+// A free-text INDIRECT entry whose name did not match a child: it lives only as
+// a pending request (no Event yet) until an admin assigns the child.
+export type PendingIndirectRequestItem = {
+  id: string;
+  date: string; // YYYY-MM-DD
+  childNameText: string;
+  startTime: string;
+  endTime: string;
+  note: string | null;
+};
+
 type Props = {
   currentUser: { id: string; name: string; email: string };
   assignedChildren: ChildOption[];
@@ -98,6 +109,8 @@ type Props = {
   substituteOn?: VertretungDay[];
   /** Own pending Vertretung requests (submitted but not yet resolved by admin). */
   pendingVertretungRequests?: PendingVertretungRequestItem[];
+  /** Own pending Indirekt requests (name unmatched, awaiting admin assignment). */
+  pendingIndirectRequests?: PendingIndirectRequestItem[];
   /** When true, the SB belongs to a pool: simplified entry form, no child selection. */
   inPool?: boolean;
 };
@@ -133,6 +146,7 @@ export function SchoolAssistantApp({
   childSchoolHolidays,
   substituteOn = [],
   pendingVertretungRequests = [],
+  pendingIndirectRequests = [],
   inPool = false,
 }: Props) {
   const today = useMemo(() => startOfDayUtc(new Date()), []);
@@ -200,6 +214,7 @@ export function SchoolAssistantApp({
             assignmentsByWeekday={assignmentsByWeekday}
             substituteOn={substituteOn}
             pendingVertretungRequests={pendingVertretungRequests}
+            pendingIndirectRequests={pendingIndirectRequests}
           />
         );
       case "woche":

--- a/src/features/vertretung-requests/facade.ts
+++ b/src/features/vertretung-requests/facade.ts
@@ -28,6 +28,7 @@ import {
   insertChildVertretungBlocks,
   insertIndirectWorkEvent,
   insertVertretungWorkEvent,
+  listIndirectRequestsForUser,
   listPendingRequests,
   listRequestsForUser,
   rejectRequest,
@@ -225,6 +226,10 @@ export const VertretungRequestsFacade = {
 
   async listForUser(userId: string, from: Date, to: Date) {
     return listRequestsForUser(userId, from, to);
+  },
+
+  async listIndirectForUser(userId: string, from: Date, to: Date) {
+    return listIndirectRequestsForUser(userId, from, to);
   },
 
   async deleteOwn(id: string, userId: string) {

--- a/src/features/vertretung-requests/services/index.ts
+++ b/src/features/vertretung-requests/services/index.ts
@@ -114,6 +114,22 @@ export async function listRequestsForUser(
   });
 }
 
+export async function listIndirectRequestsForUser(
+  substituteUserId: string,
+  from: Date,
+  to: Date,
+) {
+  return prisma.pendingVertretungRequest.findMany({
+    where: {
+      substituteUserId,
+      kind: PendingRequestKind.INDIRECT,
+      status: PendingVertretungStatus.PENDING,
+      date: { gte: from, lt: to },
+    },
+    orderBy: { date: "asc" },
+  });
+}
+
 export async function deleteOwnRequest(id: string, substituteUserId: string) {
   const request = await prisma.pendingVertretungRequest.findUnique({
     where: { id },


### PR DESCRIPTION
## Was & Warum

Ein **Schulbegleiter** konnte eine **indirekte Leistung** per Freitext-Name erfassen. Passte der Name nicht exakt zu einem Kind, wurde **kein Event** erstellt, sondern nur ein `PendingVertretungRequest(kind=INDIRECT)`. Da der Loader der Schulbegleiter-Ansicht diese Anträge nie geladen hat, blieb der Eintrag für den Schulbegleiter **unsichtbar, bis ein Admin ihn zugeordnet hat**.

Bei **Vertretungen** wurde der offene Antrag zwar schon vorab angezeigt, aber ohne Erklärung, warum er noch „hängt".

## Änderungen

- **Indirekte Leistung**: offene (noch nicht zugeordnete) Einträge erscheinen jetzt in der **Tagesansicht** als Karte – analog zu offenen Vertretungen.
- **Gemeinsamer Hinweis** auf beiden Kartentypen (Indirekt + Vertretung):
  > ⚠ Noch keinem Kind zugeordnet
  > Der eingegebene Name konnte keinem Kind zugeordnet werden. Bitte erstellen Sie den Eintrag mit dem korrekten Namen neu oder warten Sie, bis ein Admin ihn zuordnet. Bis dahin wird er nicht im Monatsabschluss berücksichtigt.
- Der Schulbegleiter kann den offenen Indirekt-Eintrag **löschen** (Löschen-Button wie bei Vertretung), um ihn mit korrektem Namen neu zu erstellen.
- Der Leer-Zustand („Keine Einträge") wird nicht mehr angezeigt, wenn an dem Tag ein offener Antrag existiert.

## Umfang / bewusste Entscheidungen

- Sichtbarkeit nur in der **Tagesansicht** (wie bei offenen Vertretungen); offene Einträge fließen **nicht** in Woche/Monat/Monatsabschluss ein, worauf der Hinweis explizit hinweist.
- Datenfluss folgt der Architektur: neuer Service `listIndirectRequestsForUser` → Facade `listIndirectForUser` → `page.tsx` → `SchoolAssistantApp` → `TabDay`.

## Test

- `tsc --noEmit` ✅
- `eslint` (inkl. boundaries) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)