### PR TITLE
feat(timesheet): prefill assigned Vertretung in Vertretung entry form

### DIFF
--- a/src/features/timesheet/components/new-entry-sheet.tsx
+++ b/src/features/timesheet/components/new-entry-sheet.tsx
@@ -108,6 +108,9 @@ export function NewEntrySheet({
   // Last value we auto-filled into the indirect name field, so a re-fill never
   // overwrites a name the user typed themselves.
   const indirectAutoFilledRef = useRef("");
+  // The day/child context we last auto-filled the Vertretung fields for, so the
+  // fill happens once per context and never fights the SB's own edits.
+  const vertretungFilledKeyRef = useRef<string | null>(null);
 
   // Child IDs that already have a work Event for this date — used to hide
   // Vertretungen the SB has already submitted an Eintrag for. Filtering by
@@ -185,6 +188,7 @@ export function NewEntrySheet({
       setVertretungQuarter(null);
       pickedTimesRef.current = false;
       indirectAutoFilledRef.current = "";
+      vertretungFilledKeyRef.current = null;
     }
     // Start/End are owned by the Stundenplan effect below, not reset here.
   }, [open, defaultDate]);
@@ -219,6 +223,32 @@ export function NewEntrySheet({
       return suggestion;
     });
   }, [open, type, workVariant, dayAssignedChildren]);
+
+  // When the admin (or a prior submission) has set up exactly one Vertretung for
+  // the day, pre-fill its name, times and ±15 flags so the SB usually only has
+  // to confirm — mirroring the indirect prefill and the Vertretung quick-picks.
+  // Filling once per (date, child) context means we never fight an edit the SB
+  // makes afterwards, and `pickedTimesRef` keeps the debounce lookup from
+  // clobbering the exact block times.
+  useEffect(() => {
+    if (!open) return;
+    if (type !== EventType.WORK || workVariant !== "VERTRETUNG") return;
+    if (availableVertretungen.length !== 1) return;
+    const v = availableVertretungen[0];
+    const block = v.timeBlocks[0];
+    if (!block) return;
+    const key = `${date}·${v.childId}`;
+    if (vertretungFilledKeyRef.current === key) return;
+    vertretungFilledKeyRef.current = key;
+    pickedTimesRef.current = true;
+    setVertretungChildName(v.childName);
+    setStartTime(block.startTime);
+    setEndTime(block.endTime);
+    setVertretungQuarter({
+      before: v.vorviertelstunde,
+      after: v.nachviertelstunde,
+    });
+  }, [open, type, workVariant, availableVertretungen, date]);
 
   const duration = useMemo(() => {
     if (!startTime || !endTime) return null;


### PR DESCRIPTION
## What & why

Follow-up to #182 (indirekt auto-prefills the assigned child). In the same spirit, when the admin (or a prior submission) has already set up a **Vertretung** for a Schulbegleiter on a given day, the **Vertretung** entry form now auto-fills that child's name, its Stundenplan times, and the ±15 (Vor-/Nachviertelstunde) flags — so the SB usually only has to confirm and sign, instead of clicking a quick-pick or retyping the name.

Previously this data was only reachable via the quick-pick buttons; the free-text field started empty and times defaulted to 08:00–17:00.

## How it works

A new `useEffect` in `new-entry-sheet.tsx` fills the Vertretung fields **when there is exactly one Vertretung available for the day** (the same list that powers the quick-picks, already excluding Vertretungen the SB has an Eintrag for):

- **Once per `(date, child)` context** (tracked via `vertretungFilledKeyRef`) — so it never fights an edit the SB makes afterwards, and it re-fills correctly when the date changes.
- Sets `pickedTimesRef = true` (like the quick-picks) so the debounce name-lookup does not clobber the exact block times.
- Only auto-fills when exactly one Vertretung is set for the day; with multiple, the SB still picks via the quick-picks (mirrors #182, which only prefills a single assigned child).

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on the file — clean (no `exhaustive-deps` warning)
- `prettier --check` — clean

Pure client-side change to a single component; no schema, action, or facade changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)