### PR TITLE
fix(2fa): guard the verify page against direct access

### DIFF
--- a/src/app/2fa/page.tsx
+++ b/src/app/2fa/page.tsx
@@ -1,58 +1,21 @@
-"use client";
-
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { redirect } from "next/navigation";
 import Image from "next/image";
 
-import { authClient } from "@/lib/auth-client";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
+import { getSession, hasPendingTwoFactor } from "@/lib/auth-guards";
+import { TwoFactorVerify } from "./two-factor-verify";
 
-export default function TwoFactorVerifyPage() {
-  const router = useRouter();
-  const [mode, setMode] = useState<"totp" | "backup">("totp");
-  const [code, setCode] = useState("");
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-  const [errorMsg, setErrorMsg] = useState("");
-
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setStatus("loading");
-    setErrorMsg("");
-
-    const result =
-      mode === "totp"
-        ? await authClient.twoFactor.verifyTotp({ code })
-        : await authClient.twoFactor.verifyBackupCode({ code });
-
-    if (result.error) {
-      setErrorMsg(
-        mode === "backup"
-          ? "Dieser Wiederherstellungscode ist ungültig oder wurde bereits verwendet."
-          : "Der Code ist ungültig oder abgelaufen. Bitte versuche es erneut.",
-      );
-      setStatus("error");
-      return;
-    }
-
-    // Full session is now established — let the home route send admins to /admin.
-    router.push("/");
-    router.refresh();
+export default async function TwoFactorVerifyPage() {
+  // A full session means 2FA is already satisfied (or wasn't required) — nothing
+  // to verify here, so send the user home.
+  const session = await getSession();
+  if (session) {
+    redirect("/");
   }
 
-  function switchMode(next: "totp" | "backup") {
-    setMode(next);
-    setCode("");
-    setStatus("idle");
-    setErrorMsg("");
+  // No full session and no 2FA challenge in flight means the user landed here
+  // without signing in. Only a pending challenge should keep this page.
+  if (!(await hasPendingTwoFactor())) {
+    redirect("/login");
   }
 
   return (
@@ -79,65 +42,7 @@ export default function TwoFactorVerifyPage() {
           />
         </div>
 
-        <Card className="border-border/60 shadow-xl">
-          <CardHeader className="gap-2 text-center">
-            <CardTitle className="text-2xl font-semibold tracking-tight">
-              Bestätigung in zwei Schritten
-            </CardTitle>
-            <CardDescription className="text-sm">
-              {mode === "totp"
-                ? "Gib den 6-stelligen Code aus deiner Authenticator-App ein."
-                : "Gib einen deiner Wiederherstellungscodes ein."}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit}>
-              <FieldGroup className="gap-6">
-                <Field>
-                  <FieldLabel htmlFor="code">
-                    {mode === "totp" ? "Code" : "Wiederherstellungscode"}
-                  </FieldLabel>
-                  <Input
-                    id="code"
-                    inputMode={mode === "totp" ? "numeric" : "text"}
-                    autoComplete="one-time-code"
-                    autoFocus
-                    required
-                    value={code}
-                    onChange={(e) => setCode(e.target.value.trim())}
-                    disabled={status === "loading"}
-                    className="h-11 text-center tracking-widest"
-                    placeholder={mode === "totp" ? "123456" : "XXXXXXXXXX"}
-                    maxLength={mode === "totp" ? 6 : 20}
-                  />
-                </Field>
-                {status === "error" && (
-                  <p className="-mt-2 text-center text-sm text-destructive">
-                    {errorMsg}
-                  </p>
-                )}
-                <Field>
-                  <Button
-                    type="submit"
-                    className="h-11 w-full text-base font-medium"
-                    disabled={status === "loading"}
-                  >
-                    {status === "loading" ? "Wird geprüft…" : "Bestätigen"}
-                  </Button>
-                </Field>
-              </FieldGroup>
-            </form>
-            <button
-              type="button"
-              onClick={() => switchMode(mode === "totp" ? "backup" : "totp")}
-              className="mt-4 w-full text-center text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-            >
-              {mode === "totp"
-                ? "Authenticator nicht zur Hand? Wiederherstellungscode verwenden"
-                : "Zurück zum Authenticator-Code"}
-            </button>
-          </CardContent>
-        </Card>
+        <TwoFactorVerify />
       </div>
     </div>
   );

--- a/src/app/2fa/two-factor-verify.tsx
+++ b/src/app/2fa/two-factor-verify.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+export function TwoFactorVerify() {
+  const router = useRouter();
+  const [mode, setMode] = useState<"totp" | "backup">("totp");
+  const [code, setCode] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus("loading");
+    setErrorMsg("");
+
+    const result =
+      mode === "totp"
+        ? await authClient.twoFactor.verifyTotp({ code })
+        : await authClient.twoFactor.verifyBackupCode({ code });
+
+    if (result.error) {
+      setErrorMsg(
+        mode === "backup"
+          ? "Dieser Wiederherstellungscode ist ungültig oder wurde bereits verwendet."
+          : "Der Code ist ungültig oder abgelaufen. Bitte versuche es erneut.",
+      );
+      setStatus("error");
+      return;
+    }
+
+    // Full session is now established — let the home route send admins to /admin.
+    router.push("/");
+    router.refresh();
+  }
+
+  function switchMode(next: "totp" | "backup") {
+    setMode(next);
+    setCode("");
+    setStatus("idle");
+    setErrorMsg("");
+  }
+
+  return (
+    <Card className="border-border/60 shadow-xl">
+      <CardHeader className="gap-2 text-center">
+        <CardTitle className="text-2xl font-semibold tracking-tight">
+          Bestätigung in zwei Schritten
+        </CardTitle>
+        <CardDescription className="text-sm">
+          {mode === "totp"
+            ? "Gib den 6-stelligen Code aus deiner Authenticator-App ein."
+            : "Gib einen deiner Wiederherstellungscodes ein."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit}>
+          <FieldGroup className="gap-6">
+            <Field>
+              <FieldLabel htmlFor="code">
+                {mode === "totp" ? "Code" : "Wiederherstellungscode"}
+              </FieldLabel>
+              <Input
+                id="code"
+                inputMode={mode === "totp" ? "numeric" : "text"}
+                autoComplete="one-time-code"
+                autoFocus
+                required
+                value={code}
+                onChange={(e) => setCode(e.target.value.trim())}
+                disabled={status === "loading"}
+                className="h-11 text-center tracking-widest"
+                placeholder={mode === "totp" ? "123456" : "XXXXXXXXXX"}
+                maxLength={mode === "totp" ? 6 : 20}
+              />
+            </Field>
+            {status === "error" && (
+              <p className="-mt-2 text-center text-sm text-destructive">
+                {errorMsg}
+              </p>
+            )}
+            <Field>
+              <Button
+                type="submit"
+                className="h-11 w-full text-base font-medium"
+                disabled={status === "loading"}
+              >
+                {status === "loading" ? "Wird geprüft…" : "Bestätigen"}
+              </Button>
+            </Field>
+          </FieldGroup>
+        </form>
+        <button
+          type="button"
+          onClick={() => switchMode(mode === "totp" ? "backup" : "totp")}
+          className="mt-4 w-full text-center text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          {mode === "totp"
+            ? "Authenticator nicht zur Hand? Wiederherstellungscode verwenden"
+            : "Zurück zum Authenticator-Code"}
+        </button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/auth-guards.ts
+++ b/src/lib/auth-guards.ts
@@ -1,10 +1,26 @@
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "./auth";
 import { isAdmin, isOwner } from "./roles";
 
 export async function getSession() {
   return auth.api.getSession({ headers: await headers() });
+}
+
+// True while a 2FA challenge is in flight. When a user with 2FA enabled signs in
+// with the correct password, better-auth deletes the full session cookie and sets
+// a short-lived signed `two_factor` cookie instead (see the twoFactor plugin), so
+// `getSession()` returns null even though the user is mid-login. The verify page
+// (/2fa) uses this to tell a legitimate pending challenge apart from someone who
+// is simply not signed in. We derive the exact cookie name (incl. the __Secure-
+// prefix in production) from better-auth's own cookie helper rather than
+// hardcoding it. Mere presence is enough for a UI-level redirect; the verify
+// endpoint still validates the signed cookie and its DB verification value.
+export async function hasPendingTwoFactor() {
+  const ctx = await auth.$context;
+  const { name } = ctx.createAuthCookie("two_factor");
+  const cookieStore = await cookies();
+  return cookieStore.has(name);
 }
 
 // Admin/owner accounts guard special-category data, so a second factor is


### PR DESCRIPTION
## Problem

Visiting `/2fa` directly — without being signed in, or without an actual 2FA challenge in flight — just left you sitting on the page. It never redirected to login or home.

The root cause: `src/app/2fa/page.tsx` was a pure **client** component with no server-side guard. Unlike its sibling `/2fa/setup` (a server component gated by `requireAuth()`), the verify page rendered unconditionally for anyone who navigated to it.

## Fix

Turn `/2fa` into a **server** component that decides before rendering:

- **Full session exists** → 2FA is already satisfied (or wasn't required) → redirect to `/`
- **No session and no pending 2FA challenge** → user isn't mid-login → redirect to `/login`
- **Genuine pending challenge** → render the verify form

### How "pending 2FA" is detected

When a user with 2FA enabled signs in with the correct password, better-auth **deletes the full session cookie** and sets a short-lived signed `two_factor` cookie instead. So `getSession()` returns `null` even though the user is legitimately mid-login — presence of that cookie is what separates a real challenge from someone who simply isn't signed in.

A new `hasPendingTwoFactor()` guard in `src/lib/auth-guards.ts` checks for it. The cookie **name** is derived from better-auth's own cookie helper (`auth.$context.createAuthCookie`) rather than hardcoded, so the `__Secure-` prefix stays correct in production. Presence is sufficient for a UI-level redirect — the verify endpoint still validates the signed cookie and its DB verification value, so this doesn't weaken any security boundary.

### Structure

The verify form is extracted into `src/app/2fa/two-factor-verify.tsx` (client), and `page.tsx` renders it inside the same background/logo layout — mirroring the existing `2fa/setup` page + `two-factor-setup.tsx` split. No behavioral change to the form itself.

## Testing

- `npx tsc --noEmit` — passes
- `eslint` (incl. `eslint-plugin-boundaries`) — passes
- `prettier --check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)