### PR TITLE
fix(vertretung): lower indirect pending note minimum to 1 char

### DIFF
--- a/src/features/vertretung-requests/schemas.ts
+++ b/src/features/vertretung-requests/schemas.ts
@@ -25,7 +25,11 @@ export const CreateIndirectPendingRequestSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Ungültiges Datum."),
   startTime: z.string().regex(/^\d{2}:\d{2}$/, "Ungültige Startzeit."),
   endTime: z.string().regex(/^\d{2}:\d{2}$/, "Ungültige Endzeit."),
-  note: z.string().min(3, "Notiz ist Pflicht (mind. 3 Zeichen).").max(2000),
+  note: z
+    .string()
+    .trim()
+    .min(1, "Notiz ist Pflicht (mind. 1 Zeichen).")
+    .max(2000),
   signaturePngBase64: z.string().min(1, "Unterschrift fehlt."),
 });
 


### PR DESCRIPTION
## Problem

Submitting an **indirekte Leistung** failed with a Zod error when the typed child name did **not** match an existing child:

```json
[{ "code": "too_small", "minimum": 3, "path": ["note"],
   "message": "Notiz ist Pflicht (mind. 3 Zeichen)." }]
```

The note minimum for indirekte Leistung was lowered to 1 character, but only the timesheet schemas were updated. The **unmatched-name** path creates a pending request validated by `CreateIndirectPendingRequestSchema` in `vertretung-requests`, whose `note` still required `min(3)`. That's why the error only appeared when the name didn't match — the matched-name path (`CreateEventSchema` / `CreateIndirectByNameSchema`) was already at `min(1)`.

## Fix

Align `CreateIndirectPendingRequestSchema.note` with the timesheet schemas: `.trim().min(1, "Notiz ist Pflicht (mind. 1 Zeichen).").max(2000)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)