### PR TITLE
feat(timesheet): entries editable/deletable until month lock, not 24h

### DIFF
--- a/src/features/timesheet/components/tab-day.tsx
+++ b/src/features/timesheet/components/tab-day.tsx
@@ -62,8 +62,6 @@ type Props = {
   pendingVertretungRequests?: PendingVertretungRequestItem[];
 };
 
-const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
-
 export function TabDay({
   currentUserId,
   selectedDate,
@@ -284,9 +282,6 @@ export function TabDay({
           totalMinutes % 60 ? ` ${totalMinutes % 60}m` : ""
         }`
       : null;
-
-  const canDelete = (ev: EventWithChild) =>
-    !locked && Date.now() - ev.createdAt.getTime() <= EDIT_WINDOW_MS;
 
   const handleDelete = async (id: string) => {
     setBusyId(id);
@@ -586,7 +581,7 @@ export function TabDay({
                 <p className="text-sm text-rose-900/80">{sickEvent.note}</p>
               )}
             </div>
-            {canDelete(sickEvent) && (
+            {!locked && (
               <Button
                 size="sm"
                 variant="ghost"
@@ -686,7 +681,7 @@ export function TabDay({
                           <Badge variant="outline">Mehrere Kinder</Badge>
                         )}
                     </div>
-                    {canDelete(ev) && (
+                    {!locked && (
                       <Button
                         size="sm"
                         variant="ghost"

--- a/src/features/timesheet/facade.ts
+++ b/src/features/timesheet/facade.ts
@@ -34,8 +34,6 @@ import {
 } from "./services";
 import { parseIsoDate } from "@/lib/dates";
 
-const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
-
 function assertMonthNotLocked(
   report: Awaited<ReturnType<typeof findMonthlyReport>>,
 ) {
@@ -190,11 +188,6 @@ export const TimesheetFacade = {
     if (!event || event.userId !== userId) {
       throw new Error("Eintrag nicht gefunden.");
     }
-    if (Date.now() - event.createdAt.getTime() > EDIT_WINDOW_MS) {
-      throw new Error(
-        "Einträge können nur innerhalb von 24 Stunden bearbeitet werden.",
-      );
-    }
     const report = await findMonthlyReport(
       userId,
       event.date.getUTCFullYear(),
@@ -217,11 +210,6 @@ export const TimesheetFacade = {
     const event = await findEventById(eventId);
     if (!event || event.userId !== userId) {
       throw new Error("Eintrag nicht gefunden.");
-    }
-    if (Date.now() - event.createdAt.getTime() > EDIT_WINDOW_MS) {
-      throw new Error(
-        "Einträge können nur innerhalb von 24 Stunden gelöscht werden.",
-      );
     }
     const report = await findMonthlyReport(
       userId,


### PR DESCRIPTION
## Problem

In the Schulbegleiter (day) view, the **Löschen** button appeared on some Einträge and not on others even when the month was *not* locked. The cause was a second, hidden gate: an entry could only be edited or deleted within **24 hours of its `createdAt`**, on top of the Monatsabschluss lock.

This was confusing because:
- The button silently disappeared once an entry aged past 24h, with no explanation in the UI.
- Admin-created / admin-edited WORK entries get a **fresh** `createdAt` when the admin touches them, so two otherwise-identical-looking entries could behave differently.

## Change

Remove the 24-hour window entirely. An Eintrag is now editable and deletable **until the month is locked** by the Lehrkraft's Monatsabschluss signature (`assertMonthNotLocked`), and only then.

- `facade.updateEvent` / `deleteEvent`: dropped the `EDIT_WINDOW_MS` check (server-side enforcement now = ownership + month lock).
- `tab-day.tsx`: the Löschen button is now gated on `!locked`, consistent with how the Vertretung delete and "Eintrag hinzufügen" buttons in the same view already work. Removed the now-unused `canDelete` helper and `EDIT_WINDOW_MS` constant.

## Notes / non-changes

- The month lock, ownership check, and the signed-vs-"Bestätigung ausstehend" distinction are unchanged.
- No behaviour change once a month is locked — entries remain immutable, exactly as before.

## Verification

- `tsc --noEmit` — clean
- `eslint` on changed files — clean
- `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)